### PR TITLE
feat(weight-receipt): per-core drafts and exclude CRNO EI TRD from FG

### DIFF
--- a/pages/weight_receipt.py
+++ b/pages/weight_receipt.py
@@ -45,12 +45,27 @@ def initialize_wr_session_state():
         st.session_state.wr_is_manual_entry = False
     if 'wr_pending_save' not in st.session_state:
         st.session_state.wr_pending_save = None
+    if 'wr_core_drafts_data' not in st.session_state:
+        st.session_state.wr_core_drafts_data = {}
+    if 'wr_current_core_no' not in st.session_state:
+        st.session_state.wr_current_core_no = None
+    if 'wr_selected_core_slots' not in st.session_state:
+        st.session_state.wr_selected_core_slots = []
 
 def _is_manual_entry_authorized():
     """Check if the current user is authorized for manual weight entry."""
     user_email = st.session_state.get('user_info', {}).get('username', '')
     authorized = [e.lower() for e in settings.weight_receipt.manual_entry_authorized_emails]
     return user_email.lower() in authorized
+
+
+# Material types whose weight receipts should NOT post to the Finished Goods Transfer sheet.
+FG_EXCLUDED_MATERIALS = {"CRNO EI TRD"}
+
+
+def _should_post_to_finished_goods() -> bool:
+    material = (st.session_state.get('wr_material_type') or "").strip().upper()
+    return material not in FG_EXCLUDED_MATERIALS
 
 
 @st.dialog("Confirm Weight Receipt Save", width="large")
@@ -326,8 +341,13 @@ def render_weight_receipt_form():
             
             # --- Load Drafts and Initialize State (runs only on JC change) ---
             if st.session_state.get('current_jc_for_wr') != selected_jc_str:
-                drafts, draft_sets, draft_total_weight, draft_core_remark = services.weight_receipt.get_weight_receipt_drafts(selected_jc_str)
+                drafts, draft_sets, draft_total_weight, draft_core_remark, core_drafts_dict = services.weight_receipt.get_weight_receipt_drafts(selected_jc_str)
                 st.session_state.wr_draft_data = drafts or {}
+                st.session_state.wr_core_drafts_data = core_drafts_dict or {}
+                # Look up material type from the flat Sales Order sheet — Sales Order-JC doesn't carry it.
+                st.session_state.wr_material_type = services.weight_receipt.get_material_type_for_job_card(selected_jc_str)
+                st.session_state.wr_current_core_no = None
+                st.session_state.wr_selected_core_slots = []
                 
                 # When JC changes, reset the session state for weights, remarks, deductions, and selection
                 st.session_state.wr_weights = {}
@@ -402,7 +422,6 @@ def render_weight_receipt_form():
 
             # --- Set Selection UI (varies by order type) ---
             if order_type == "CORE_BUILDING":
-                # Original set-based logic for core building orders
                 total_sets_in_jc = int(selected_jc.get('number_of_cores', 0))
                 completed_sets = services.weight_receipt.get_receipted_sets_for_job_card(selected_jc_str)
                 remaining_sets = total_sets_in_jc - completed_sets
@@ -416,41 +435,70 @@ def render_weight_receipt_form():
                     st.warning("All sets for this Job Card have already been receipted.", icon="⚠️")
                     st.stop()
 
-                # --- Number of sets for this receipt ---
-                sets_for_this_receipt_val = st.session_state.get('wr_sets_for_receipt', min(1, remaining_sets))
-                if sets_for_this_receipt_val > remaining_sets:
-                    st.warning(f"Draft has {sets_for_this_receipt_val} sets, but only {remaining_sets} remain. Please adjust or clear draft.", icon="⚠️")
-                    if st.button("Reset Sets and Clear Draft"):
-                        st.session_state.wr_sets_for_receipt = remaining_sets
-                        st.session_state.wr_weights = {}
-                        st.session_state.wr_remarks = {}
-                        st.session_state.wr_total_weight = 0.0
-                        st.session_state.wr_draft_data = {}
-                        st.session_state.last_selected_index = None
-                        services.weight_receipt.clear_weight_receipt_drafts(selected_jc_str)
-                        st.toast("Sets reset and draft cleared.", icon="🗑️")
-                        st.rerun()
-                    sets_for_this_receipt_val = remaining_sets
+                # --- Core slot multiselect ---
+                # User picks which physical core slots this single weight receipt will cover.
+                # Each in-progress draft is keyed by its starting slot; selecting the same
+                # starting slot prefills the in-progress weight/remark (resume draft).
+                core_drafts_data = st.session_state.get('wr_core_drafts_data', {})
+                receipted_slots = set(range(1, completed_sets + 1))
+                available_slots = [s for s in range(1, total_sets_in_jc + 1) if s not in receipted_slots]
 
-                sets_for_this_receipt = st.number_input(
-                    "Number of Cores for this Receipt",
-                    min_value=1,
-                    max_value=remaining_sets,
-                    value=sets_for_this_receipt_val,
-                    step=1,
-                    key='wr_sets_for_receipt_input' 
+                def _slot_label(s: int) -> str:
+                    if s in core_drafts_data:
+                        d = core_drafts_data[s]
+                        wt = float(d.get('weight') or 0.0)
+                        n = int(d.get('sets') or 1)
+                        span = f"+{n-1}" if n > 1 else ""
+                        return f"Core #{s}{span} (draft: {wt:.2f} kg)"
+                    return f"Core #{s}"
+
+                # Default selection: resume the first existing draft, else first available slot
+                if 'wr_selected_core_slots' not in st.session_state or not st.session_state.wr_selected_core_slots:
+                    drafted = sorted([s for s in core_drafts_data if s in available_slots])
+                    if drafted:
+                        first = drafted[0]
+                        n = int(core_drafts_data[first].get('sets') or 1)
+                        st.session_state.wr_selected_core_slots = [first + k for k in range(n) if (first + k) in available_slots]
+                    else:
+                        st.session_state.wr_selected_core_slots = [available_slots[0]]
+
+                option_to_slot = {_slot_label(s): s for s in available_slots}
+                slot_to_option = {s: lbl for lbl, s in option_to_slot.items()}
+                default_options = [slot_to_option[s] for s in st.session_state.wr_selected_core_slots if s in slot_to_option]
+
+                selected_options = st.multiselect(
+                    "Cores to Weigh in This Receipt",
+                    options=list(option_to_slot.keys()),
+                    default=default_options,
+                    help="Select one or more physical core slots. Pick a single slot to weigh one core at a time, or several to weigh them together on the scale. Slots labelled '(draft …)' have an in-progress draft you can resume by re-selecting them."
                 )
+                selected_slots = sorted(option_to_slot[opt] for opt in selected_options)
 
-                if 'wr_sets_for_receipt' in st.session_state and st.session_state.wr_sets_for_receipt != sets_for_this_receipt:
-                    st.session_state.wr_weights = {}
-                    st.session_state.wr_remarks = {}
-                    st.session_state.wr_total_weight = 0.0
-                    st.session_state.wr_draft_data = {}
-                    st.session_state.last_selected_index = None
-                    services.weight_receipt.clear_weight_receipt_drafts(selected_jc_str)
-                    st.toast("Number of sets changed. Previous draft cleared.", icon="🗑️")
+                if not selected_slots:
+                    st.info("Select at least one core slot to weigh.", icon="ℹ️")
+                    st.stop()
+
+                sets_for_this_receipt = len(selected_slots)
+                current_core_no = selected_slots[0]
+
+                # If selection changed, prefill weight/remark from a matching draft (if any) and rerun
+                if st.session_state.wr_selected_core_slots != selected_slots:
+                    st.session_state.wr_selected_core_slots = selected_slots
+                    matching_draft = core_drafts_data.get(current_core_no)
+                    if matching_draft is not None and int(matching_draft.get('sets') or 1) == sets_for_this_receipt:
+                        st.session_state.wr_total_weight = float(matching_draft.get('weight') or 0.0)
+                        st.session_state.wr_core_remark = matching_draft.get('remark', '') or ''
+                    else:
+                        st.session_state.wr_total_weight = 0.0
+                        st.session_state.wr_core_remark = ''
+                    st.rerun()
 
                 st.session_state.wr_sets_for_receipt = sets_for_this_receipt
+                st.session_state.wr_current_core_no = current_core_no
+                st.caption(
+                    f"This receipt will cover {sets_for_this_receipt} core(s): "
+                    + ", ".join(f"#{s}" for s in selected_slots)
+                )
             
             else:
                 # Weight-based logic for loose strips and EI ready orders
@@ -829,12 +877,18 @@ def render_weight_receipt_form():
                         if success:
                             st.success(f"Weight Receipt {generated_wr_number} saved successfully!")
                             user_id = st.session_state.get('user_info', {}).get('username', 'SYSTEM')
-                            services.weight_receipt.save_to_finished_goods(
-                                user_id=user_id,
-                                job_card=selected_jc['job_card_number'],
-                                fg_qty=actual_total_weight - deduction,
-                                weight_receipt_number=generated_wr_number
-                            )
+                            if _should_post_to_finished_goods():
+                                services.weight_receipt.save_to_finished_goods(
+                                    user_id=user_id,
+                                    job_card=selected_jc['job_card_number'],
+                                    fg_qty=actual_total_weight - deduction,
+                                    weight_receipt_number=generated_wr_number
+                                )
+                            else:
+                                st.toast(
+                                    f"Skipped Finished Goods entry ({st.session_state.get('wr_material_type', 'N/A')} is excluded).",
+                                    icon="ℹ️"
+                                )
 
                             # Selective draft clearing: only clear drafts for designs that were saved
                             services.weight_receipt.clear_drafts_for_design_indices(
@@ -866,8 +920,15 @@ def render_weight_receipt_form():
 
             elif weight_entry_type == "Building Core":
                 _render_designs_grid(designs, drafts, is_itemized_mode=False, editable=False)
-                st.markdown("<h6>Enter Total Actual Weight & Remark:</h6>", unsafe_allow_html=True)
-                
+
+                selected_slots = st.session_state.get('wr_selected_core_slots', []) or []
+                slot_label = (
+                    f"Core #{selected_slots[0]}"
+                    if len(selected_slots) == 1
+                    else f"Cores {', '.join('#' + str(s) for s in selected_slots)}"
+                ) if selected_slots else "Selected Cores"
+                st.markdown(f"<h6>Enter Total Actual Weight & Remark for {slot_label}:</h6>", unsafe_allow_html=True)
+
                 # --- UI for Weight and Remark Inputs ---
                 core_input_col1, core_input_col2 = st.columns(2)
                 with core_input_col1:
@@ -943,14 +1004,15 @@ def render_weight_receipt_form():
 
                 if save_draft_clicked_core:
                     with st.spinner("Saving draft..."):
+                        current_core_no = int(st.session_state.get('wr_current_core_no') or 1)
                         services.weight_receipt.save_weight_receipt_draft(
                             job_card=selected_jc_str,
-                            design_index=-1,
+                            design_index=-current_core_no,
                             weight=st.session_state.wr_total_weight,
                             remark=st.session_state.get('wr_core_remark', ''),
                             sets_for_this_receipt=st.session_state.get('wr_sets_for_receipt', 0)
                         )
-                        st.toast("Draft saved!", icon="📝")
+                        st.toast(f"Draft saved for Core #{current_core_no}!", icon="📝")
                         st.rerun()
                 st.markdown("---")
                 if st.button("Save Weight Receipt", key="save_wr_button_core"):
@@ -1015,17 +1077,34 @@ def render_weight_receipt_form():
                         if success:
                             st.success(f"Weight Receipt {generated_wr_number} saved successfully!")
                             user_id = st.session_state.get('user_info', {}).get('username', 'SYSTEM')
-                            services.weight_receipt.save_to_finished_goods(
-                                user_id=user_id,
-                                job_card=selected_jc['job_card_number'],
-                                fg_qty=actual_total_weight - deduction,
-                                weight_receipt_number=generated_wr_number
+                            if _should_post_to_finished_goods():
+                                services.weight_receipt.save_to_finished_goods(
+                                    user_id=user_id,
+                                    job_card=selected_jc['job_card_number'],
+                                    fg_qty=actual_total_weight - deduction,
+                                    weight_receipt_number=generated_wr_number
+                                )
+                            else:
+                                st.toast(
+                                    f"Skipped Finished Goods entry ({st.session_state.get('wr_material_type', 'N/A')} is excluded).",
+                                    icon="ℹ️"
+                                )
+                            # Clear only the draft for the core slot(s) covered by this receipt,
+                            # so other in-progress core drafts for this JC are preserved.
+                            cleared_slots = list(st.session_state.get('wr_selected_core_slots') or [])
+                            if not cleared_slots:
+                                cleared_slots = [int(st.session_state.get('wr_current_core_no') or 1)]
+                            slot_indices = [-s for s in cleared_slots]
+                            services.weight_receipt.clear_drafts_for_design_indices(
+                                selected_jc['job_card_number'], slot_indices
                             )
-                            services.weight_receipt.clear_weight_receipt_drafts(selected_jc['job_card_number'])
                             st.session_state.wr_weights = {}
                             st.session_state.wr_remarks = {}
                             st.session_state.wr_total_weight = 0.0
                             st.session_state.wr_draft_data = {}
+                            st.session_state.wr_core_drafts_data = {}
+                            st.session_state.wr_current_core_no = None
+                            st.session_state.wr_selected_core_slots = []
                             st.session_state.last_selected_index = None
                             st.session_state.wr_is_manual_entry = False
 

--- a/src/data_entry/service/weight_receipt_service.py
+++ b/src/data_entry/service/weight_receipt_service.py
@@ -236,6 +236,49 @@ class WeightReceiptService:
             logger.error(f"Error calculating cumulative weight for JC {job_card_number}: {e}")
             return 0.0
     
+    def get_material_type_for_job_card(self, job_card_number: str) -> str:
+        """
+        Looks up the material type for a job card from the flat 'Sales Order' sheet.
+        The Sales Order-JC sheet does not store material type, so we read it from
+        the per-design rows in 'Sales Order' where it lives in the 'type' column.
+        Returns an empty string if no match is found.
+        """
+        try:
+            df = self.google_service.get_worksheet_data(self.spreadsheet_id, "Sales Order", header_row=1)
+            if df is None or df.empty:
+                return ""
+
+            # Identify the job card column (varies in casing/naming across writes)
+            jc_col = None
+            for candidate in ("Job Card", "job_card_number", "Job Card No", "job_card", "JobCard"):
+                if candidate in df.columns:
+                    jc_col = candidate
+                    break
+            if jc_col is None:
+                logger.warning("get_material_type_for_job_card: no recognizable Job Card column in 'Sales Order' sheet.")
+                return ""
+
+            # Identify the material/type column
+            type_col = None
+            for candidate in ("type", "Type", "material_type", "Material Type", "Material"):
+                if candidate in df.columns:
+                    type_col = candidate
+                    break
+            if type_col is None:
+                logger.warning("get_material_type_for_job_card: no recognizable type/material column in 'Sales Order' sheet.")
+                return ""
+
+            df[jc_col] = df[jc_col].astype(str).str.strip().str.lower()
+            jc_rows = df[df[jc_col] == job_card_number.strip().lower()]
+            if jc_rows.empty:
+                return ""
+
+            value = jc_rows.iloc[0].get(type_col)
+            return "" if pd.isna(value) else str(value).strip()
+        except Exception as e:
+            logger.error(f"Error in get_material_type_for_job_card for JC {job_card_number}: {e}")
+            return ""
+
     def get_order_type_for_job_card(self, job_card_number: str) -> str:
         """
         Retrieves the order type for a given job card from the Sales Order-JC sheet.
@@ -317,27 +360,31 @@ class WeightReceiptService:
             logger.error(f"Error in save_weight_receipt_draft for JC {job_card}: {e}")
             return False
 
-    def get_weight_receipt_drafts(self, job_card: str) -> tuple[dict, int | None, float | None, str | None]:
+    def get_weight_receipt_drafts(self, job_card: str) -> tuple[dict, int | None, float | None, str | None, dict]:
         """
         Retrieves the latest draft data for a given job card.
         Returns a tuple: (
             dictionary mapping design_index to its data (including design_deduction),
             the number of sets for the draft session,
-            the total weight if a 'Building Core' draft exists,
-            the remark if a 'Building Core' draft exists
+            the total weight from the latest 'Building Core' draft (legacy/back-compat),
+            the remark from the latest 'Building Core' draft (legacy/back-compat),
+            dictionary mapping core slot number (1-indexed) to its draft data
         ).
+
+        Core building drafts are stored with negative DesignIndex where
+        index = -core_slot_number, so multiple cores can have independent drafts.
         """
         try:
             sheet_name = "Weight Receipt Draft"
             df = self.google_service.get_worksheet_data(self.spreadsheet_id, sheet_name)
             if df is None or df.empty or 'JobCardNumber' not in df.columns:
-                return {}, None, None, None
+                return {}, None, None, None, {}
 
             # Filter for the job card and ensure correct types
             drafts_df = df[df['JobCardNumber'] == job_card].copy()
             if drafts_df.empty:
-                return {}, None, None, None
-            
+                return {}, None, None, None, {}
+
             drafts_df['Timestamp'] = pd.to_datetime(drafts_df['Timestamp'], errors='coerce')
             drafts_df['DesignIndex'] = pd.to_numeric(drafts_df['DesignIndex'], errors='coerce')
             drafts_df.dropna(subset=['Timestamp', 'DesignIndex'], inplace=True)
@@ -347,14 +394,25 @@ class WeightReceiptService:
             latest_entry = drafts_df.sort_values('Timestamp', ascending=False).iloc[0]
             draft_sets_value = int(pd.to_numeric(latest_entry.get('ReceiptSets'), errors='coerce'))
 
-            # Separate Building Core drafts (index -1) from Loose Strips drafts
-            core_drafts = drafts_df[drafts_df['DesignIndex'] == -1]
+            # Separate Building Core drafts (negative index) from Loose Strips drafts
+            core_drafts = drafts_df[drafts_df['DesignIndex'] < 0]
             loose_strip_drafts = drafts_df[drafts_df['DesignIndex'] >= 0]
 
-            # Get the latest total weight and remark if a core draft exists
+            # Build per-core dict keyed by core slot number (1-indexed)
+            core_drafts_dict = {}
             draft_total_weight = None
             draft_core_remark = None
             if not core_drafts.empty:
+                latest_per_core = core_drafts.sort_values('Timestamp', ascending=False).drop_duplicates(subset=['DesignIndex'], keep='first')
+                for _, row in latest_per_core.iterrows():
+                    core_no = int(-row['DesignIndex'])
+                    remark = str(row.get('Remark', '')) if pd.notna(row.get('Remark')) else ''
+                    core_drafts_dict[core_no] = {
+                        'weight': float(pd.to_numeric(row['ActualWeight'], errors='coerce') or 0.0),
+                        'remark': remark,
+                        'sets': int(row.get('ReceiptSets', 1))
+                    }
+                # Legacy fields: latest core draft overall
                 latest_core_draft = core_drafts.sort_values('Timestamp', ascending=False).iloc[0]
                 draft_total_weight = pd.to_numeric(latest_core_draft['ActualWeight'], errors='coerce')
                 draft_core_remark = str(latest_core_draft.get('Remark', '')) if pd.notna(latest_core_draft.get('Remark')) else ''
@@ -370,17 +428,17 @@ class WeightReceiptService:
                 # Get design_deduction, default to 0.0 if column doesn't exist or value is missing
                 design_deduction = pd.to_numeric(row.get('DesignDeduction', 0.0), errors='coerce')
                 design_deduction = design_deduction if pd.notna(design_deduction) else 0.0
-                
+
                 result[row['DesignIndex']] = {
                     'weight': pd.to_numeric(row['ActualWeight'], errors='coerce'),
                     'remark': remark,
                     'design_deduction': design_deduction,
                     'sets': int(row.get('ReceiptSets', 1))
                 }
-            return result, draft_sets_value, draft_total_weight, draft_core_remark
+            return result, draft_sets_value, draft_total_weight, draft_core_remark, core_drafts_dict
         except Exception as e:
             logger.error(f"Error in get_weight_receipt_drafts for JC {job_card}: {e}")
-            return {}, None, None, None
+            return {}, None, None, None, {}
 
     def clear_weight_receipt_drafts(self, job_card: str) -> bool:
         """Removes all draft entries for a given job card from the draft sheet."""

--- a/tests/test_design_deduction_integration.py
+++ b/tests/test_design_deduction_integration.py
@@ -66,7 +66,7 @@ def test_draft_save_and_load():
     # Test 3: Load drafts and verify design_deduction values
     print("\n=== Test 3: Load Drafts and Verify ===")
     try:
-        drafts, sets, total_weight, core_remark = services.weight_receipt.get_weight_receipt_drafts(test_job_card)
+        drafts, sets, total_weight, core_remark, core_drafts = services.weight_receipt.get_weight_receipt_drafts(test_job_card)
         
         print(f"✓ Loaded {len(drafts)} draft(s)")
         
@@ -122,7 +122,7 @@ def test_draft_save_and_load():
             return False
         
         # Verify drafts are cleared
-        drafts, _, _, _ = services.weight_receipt.get_weight_receipt_drafts(test_job_card)
+        drafts, _, _, _, _ = services.weight_receipt.get_weight_receipt_drafts(test_job_card)
         if len(drafts) == 0:
             print("✓ Verified drafts are cleared")
         else:


### PR DESCRIPTION
Core building drafts now key by physical core slot (-core_no) instead of a single -1 sentinel, so weighing one core at a time no longer clobbers in-progress drafts for other cores. Replaces the dual sets/slot inputs with a single multiselect that lets the user pick any combination of cores for one receipt and resume drafts by re-selecting the same slots.

Also stops posting CRNO EI TRD weight receipts to Finished Goods Transfer. Material type is looked up from the flat Sales Order sheet (Sales Order-JC doesn't carry it) and cached in session state on JC selection.