### PR TITLE
Add PDF generator and Delivery Challan feature

### DIFF
--- a/config.py
+++ b/config.py
@@ -62,3 +62,9 @@ def load_settings() -> Settings:
     )
 
 settings = load_settings()
+# Google Sheets Constants (Delivery Challan Feature)
+DELIVERY_CHALLAN_SHEET = "Delivery Challan"
+CONSIGNEE_MASTER_SHEET = "Consignee Master"
+FINANCIAL_YEAR = "25-26"  # update every April 1
+RM_INWARD_ISSUE_SHEET = "RM inward_Issue format"
+RM_USED_SHEET = "RM Used"

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ DEV_MODE = settings.app.dev_mode
 # --- Page Configuration ---
 st.set_page_config(
     page_title="AEL ERP",
+    
     page_icon="assets/logofinal.png",
     layout="wide",
     initial_sidebar_state="expanded"

--- a/pages/delivery_challan.py
+++ b/pages/delivery_challan.py
@@ -1,0 +1,601 @@
+import streamlit as st
+import pandas as pd
+import time
+from datetime import datetime
+from pydantic import ValidationError
+
+from src.data_entry.service.delivery_challan_service import DeliveryChallanService
+from src.data_entry.models.delivery_challan_models import (
+    DeliveryChallanRequest,
+    DeliveryChallanItem,
+)
+from theme.components import render_main_header
+
+
+@st.cache_resource(ttl=600)
+def _get_service():
+    return DeliveryChallanService()
+
+
+@st.cache_data(ttl=300)
+def _load_coil_numbers(_svc):
+    return _svc.get_coil_numbers()
+
+
+@st.cache_data(ttl=300)
+def _load_parties(_svc):
+    return _svc.get_rm_parties()
+
+
+@st.cache_data(ttl=300)
+def _load_consignees(_svc):
+    return [c.get("Party Name", "") for c in _svc.get_consignees()]
+
+
+def _clear_dc_caches():
+    _load_coil_numbers.clear()
+    _load_parties.clear()
+    _load_consignees.clear()
+
+
+# ──────────────────────────────────────────────────
+# Shared helper: create challan + handle missing data
+# ──────────────────────────────────────────────────
+
+def _handle_challan_generation(service: DeliveryChallanService, request: DeliveryChallanRequest):
+    """
+    Validates for missing fields. If any are missing, offers an Excel download.
+    Otherwise creates the challan, saves to Sheets, and provides the PDF download.
+    """
+    missing = service.check_missing_fields(request)
+
+    if missing:
+        st.warning(
+            f"⚠️ **{len(missing)} missing field(s) detected.** "
+            "The PDF cannot be generated until these are filled in."
+        )
+
+        missing_df = pd.DataFrame([
+            {"Field": m.display_name, "Source": m.source}
+            for m in missing
+        ])
+        st.dataframe(missing_df, use_container_width=True, hide_index=True)
+
+        excel_bytes = service.generate_missing_excel(request, missing)
+        st.download_button(
+            label="📥 Download Missing Fields Excel",
+            data=excel_bytes,
+            file_name=f"missing_fields_{datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx",
+            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            type="primary",
+        )
+        return
+
+    # No missing fields — proceed with challan creation
+    with st.spinner("Creating Delivery Challan..."):
+        try:
+            challan_number = service.create_delivery_challan(request)
+            st.success(f"✅ Challan **{challan_number}** created and saved to Google Sheets!")
+
+            pdf_bytes = service.generate_challan_pdf(challan_number)
+            st.download_button(
+                label="📄 Download Challan PDF",
+                data=pdf_bytes,
+                file_name=f"DC_{challan_number.replace('/', '_')}.pdf",
+                mime="application/pdf",
+                type="primary",
+            )
+        except Exception as e:
+            st.error(f"❌ Failed to create challan: {e}")
+
+
+# ──────────────────────────────────────────────────
+# Coil Item Editor (shared between modes)
+# ──────────────────────────────────────────────────
+
+def _render_item_editor(items: list, key_prefix: str):
+    """Displays a data editor for coil items and returns the edited items list."""
+    if not items:
+        st.info("No coil items added yet.")
+        return items
+
+    df = pd.DataFrame([item.dict() for item in items])
+
+    display_cols = [
+        "coil_number", "grade", "width", "thk", "coating",
+        "weight_kg", "weight_mt", "nature_of_processing",
+        "hsn_code", "rate_per_mt", "value",
+    ]
+    display_df = df[[c for c in display_cols if c in df.columns]].copy()
+
+    col_config = {
+        "coil_number": st.column_config.TextColumn("Coil No", disabled=True),
+        "grade": st.column_config.TextColumn("Grade", disabled=True),
+        "width": st.column_config.NumberColumn("Width", disabled=True),
+        "thk": st.column_config.NumberColumn("Thk", disabled=True),
+        "coating": st.column_config.TextColumn("Coating", disabled=True),
+        "weight_kg": st.column_config.NumberColumn("Wt (kg)", disabled=True, format="%.2f"),
+        "weight_mt": st.column_config.NumberColumn("Wt (MT)", disabled=True, format="%.3f"),
+        "nature_of_processing": st.column_config.TextColumn("Process"),
+        "hsn_code": st.column_config.TextColumn("HSN"),
+        "rate_per_mt": st.column_config.NumberColumn("Rate/MT", format="%.2f"),
+        "value": st.column_config.NumberColumn("Value", format="%.2f"),
+    }
+
+    edited_df = st.data_editor(
+        display_df,
+        column_config=col_config,
+        use_container_width=True,
+        hide_index=True,
+        key=f"{key_prefix}_items_editor",
+    )
+
+    # Apply edits back to item objects
+    updated_items = []
+    for i, item in enumerate(items):
+        item_dict = item.dict()
+        if i < len(edited_df):
+            row = edited_df.iloc[i]
+            item_dict["nature_of_processing"] = row.get("nature_of_processing", item.nature_of_processing)
+            item_dict["hsn_code"] = row.get("hsn_code", item.hsn_code)
+            item_dict["rate_per_mt"] = float(row.get("rate_per_mt", item.rate_per_mt))
+            item_dict["value"] = float(row.get("value", item.value))
+        updated_items.append(DeliveryChallanItem(**item_dict))
+
+    return updated_items
+
+
+def _render_common_fields(key_prefix: str, consignee_names: list, default_party: str = ""):
+    """Render the common challan fields (type, party, vehicle, etc.)."""
+    col1, col2 = st.columns(2)
+
+    with col1:
+        challan_type = st.selectbox(
+            "Challan Type",
+            options=["job_work", "return"],
+            format_func=lambda x: "Job Work" if x == "job_work" else "Return",
+            key=f"{key_prefix}_challan_type",
+        )
+
+        # Try to find default party index
+        party_index = None
+        if default_party:
+            try:
+                party_index = consignee_names.index(default_party)
+            except ValueError:
+                party_index = None
+
+        party_name = st.selectbox(
+            "Party Name (from Consignee Master)",
+            options=consignee_names,
+            index=party_index,
+            placeholder="Select a party",
+            key=f"{key_prefix}_party_name",
+        )
+
+        challan_date = st.date_input(
+            "Challan Date",
+            value=datetime.now().date(),
+            key=f"{key_prefix}_challan_date",
+        )
+
+    with col2:
+        vehicle_no = st.text_input("Vehicle No", key=f"{key_prefix}_vehicle_no")
+        ewaybill_no = st.text_input("E-Waybill No", key=f"{key_prefix}_ewaybill_no")
+        hsn_code = st.text_input("HSN Code", value="7208", key=f"{key_prefix}_hsn_code")
+
+    col3, col4 = st.columns(2)
+    with col3:
+        rounded_off = st.number_input("Rounded Off", value=0.0, step=0.01, format="%.2f", key=f"{key_prefix}_rounded_off")
+    with col4:
+        remarks = st.text_input("Remarks", key=f"{key_prefix}_remarks")
+
+    return {
+        "challan_type": challan_type,
+        "party_name": party_name or "",
+        "challan_date": challan_date,
+        "vehicle_no": vehicle_no,
+        "ewaybill_no": ewaybill_no,
+        "hsn_code": hsn_code,
+        "rounded_off": rounded_off,
+        "remarks": remarks,
+    }
+
+
+# ══════════════════════════════════════════════════
+# MODE 1: Manual Entry
+# ══════════════════════════════════════════════════
+
+def _render_manual_mode(service: DeliveryChallanService, consignee_names: list):
+    """Manual coil-by-coil entry mode (existing functionality)."""
+    st.markdown("### 📝 Manual Entry")
+    st.info("Add coils manually and generate a Delivery Challan.")
+
+    if "dc_manual_items" not in st.session_state:
+        st.session_state.dc_manual_items = []
+
+    # --- Add Coil Form ---
+    with st.expander("➕ Add Coil Item", expanded=not st.session_state.dc_manual_items):
+        col1, col2 = st.columns(2)
+        with col1:
+            coil_number = st.text_input("Coil Number", key="dc_manual_coil_number")
+            grade = st.text_input("Grade", key="dc_manual_grade")
+            width = st.number_input("Width (mm)", min_value=0.0, step=0.1, key="dc_manual_width")
+            thk = st.number_input("Thk (mm)", min_value=0.0, step=0.01, key="dc_manual_thk")
+        with col2:
+            coating = st.text_input("Coating", key="dc_manual_coating")
+            weight_kg = st.number_input("Weight (kg)", min_value=0.0, step=0.01, key="dc_manual_weight_kg")
+            rate_per_mt = st.number_input("Rate per MT", min_value=0.0, step=0.01, key="dc_manual_rate")
+            nature_of_processing = st.selectbox("Process", options=["Slitting", "Other"], key="dc_manual_process")
+
+        hsn_code_item = st.text_input("HSN Code", value="7208", key="dc_manual_hsn_item")
+
+        if st.button("Add Coil", key="dc_manual_add_btn"):
+            if not coil_number.strip():
+                st.warning("Please enter a Coil Number.")
+            elif weight_kg <= 0:
+                st.warning("Weight must be greater than 0.")
+            else:
+                weight_mt = weight_kg / 1000
+                value = weight_mt * rate_per_mt
+                item = DeliveryChallanItem(
+                    coil_number=coil_number,
+                    description=grade,
+                    grade=grade,
+                    width=width,
+                    thk=thk,
+                    coating=coating,
+                    weight_kg=weight_kg,
+                    weight_mt=weight_mt,
+                    nature_of_processing=nature_of_processing,
+                    hsn_code=hsn_code_item,
+                    rate_per_mt=rate_per_mt,
+                    value=value,
+                )
+                st.session_state.dc_manual_items.append(item)
+                st.success(f"Coil **{coil_number}** added!")
+                st.rerun()
+
+    # --- Display & Edit Items ---
+    if st.session_state.dc_manual_items:
+        st.markdown("#### Coils in Challan")
+        st.session_state.dc_manual_items = _render_item_editor(
+            st.session_state.dc_manual_items, "dc_manual"
+        )
+
+        if st.button("🗑️ Clear All Coils", key="dc_manual_clear"):
+            st.session_state.dc_manual_items = []
+            st.rerun()
+
+        st.markdown("---")
+        st.markdown("#### Challan Details")
+        fields = _render_common_fields("dc_manual", consignee_names)
+
+        if st.button("🚀 Generate Delivery Challan", type="primary", key="dc_manual_generate"):
+            if not fields["party_name"]:
+                st.warning("Please select a Party Name.")
+                return
+
+            request = DeliveryChallanRequest(
+                challan_type=fields["challan_type"],
+                challan_date=fields["challan_date"],
+                party_name=fields["party_name"],
+                vehicle_no=fields["vehicle_no"] or None,
+                ewaybill_no=fields["ewaybill_no"] or None,
+                hsn_code=fields["hsn_code"],
+                rounded_off=fields["rounded_off"],
+                remarks=fields["remarks"] or None,
+                items=st.session_state.dc_manual_items,
+            )
+            _handle_challan_generation(service, request)
+
+
+# ══════════════════════════════════════════════════
+# MODE 2: From Coil Number
+# ══════════════════════════════════════════════════
+
+def _render_coil_mode(service: DeliveryChallanService, consignee_names: list, coil_numbers: list):
+    """Generate challan by selecting coil number(s) from RM Inward."""
+    st.markdown("### 🔢 From Coil Number")
+    st.info("Select coil(s) from RM Inward to auto-populate the challan.")
+
+    selected_coils = st.multiselect(
+        "Select Coil Number(s)",
+        options=coil_numbers,
+        key="dc_coil_selected",
+    )
+
+    if not selected_coils:
+        return
+
+    # Build request from coils
+    try:
+        request = service.build_request_from_coils(selected_coils)
+    except Exception as e:
+        st.error(f"❌ Error: {e}")
+        return
+
+    st.markdown("#### Auto-populated Coil Items")
+    st.caption("Edit Rate per MT and Value below. Other fields are from RM Inward.")
+
+    if "dc_coil_items" not in st.session_state or st.session_state.get("dc_coil_last_selection") != selected_coils:
+        st.session_state.dc_coil_items = list(request.items)
+        st.session_state.dc_coil_last_selection = list(selected_coils)
+
+    st.session_state.dc_coil_items = _render_item_editor(
+        st.session_state.dc_coil_items, "dc_coil"
+    )
+
+    st.markdown("---")
+    st.markdown("#### Challan Details")
+    fields = _render_common_fields("dc_coil", consignee_names, default_party=request.party_name)
+
+    if st.button("🚀 Generate Delivery Challan", type="primary", key="dc_coil_generate"):
+        if not fields["party_name"]:
+            st.warning("Please select a Party Name.")
+            return
+
+        final_request = DeliveryChallanRequest(
+            challan_type=fields["challan_type"],
+            challan_date=fields["challan_date"],
+            party_name=fields["party_name"],
+            vehicle_no=fields["vehicle_no"] or None,
+            ewaybill_no=fields["ewaybill_no"] or None,
+            hsn_code=fields["hsn_code"],
+            rounded_off=fields["rounded_off"],
+            remarks=fields["remarks"] or None,
+            items=st.session_state.dc_coil_items,
+        )
+        _handle_challan_generation(service, final_request)
+
+
+# ══════════════════════════════════════════════════
+# MODE 3: From Party
+# ══════════════════════════════════════════════════
+
+def _render_party_mode(service: DeliveryChallanService, consignee_names: list, parties: list):
+    """Generate challan by selecting a party first, then its coils."""
+    st.markdown("### 🏢 From Party")
+    st.info("Select a party (supplier), then select coils belonging to that party.")
+
+    selected_party = st.selectbox(
+        "Select Party",
+        options=parties,
+        index=None,
+        placeholder="Choose a party...",
+        key="dc_party_selected",
+    )
+
+    if not selected_party:
+        return
+
+    party_coils = service.get_coils_by_party(selected_party)
+    if not party_coils:
+        st.warning(f"No coils found for party **{selected_party}** in RM Inward.")
+        return
+
+    selected_coils = st.multiselect(
+        "Select Coil Number(s)",
+        options=party_coils,
+        key="dc_party_coils_selected",
+    )
+
+    if not selected_coils:
+        return
+
+    try:
+        request = service.build_request_from_coils(selected_coils, party_name=selected_party)
+    except Exception as e:
+        st.error(f"❌ Error: {e}")
+        return
+
+    st.markdown("#### Auto-populated Coil Items")
+
+    if "dc_party_items" not in st.session_state or st.session_state.get("dc_party_last_selection") != selected_coils:
+        st.session_state.dc_party_items = list(request.items)
+        st.session_state.dc_party_last_selection = list(selected_coils)
+
+    st.session_state.dc_party_items = _render_item_editor(
+        st.session_state.dc_party_items, "dc_party"
+    )
+
+    st.markdown("---")
+    st.markdown("#### Challan Details")
+    fields = _render_common_fields("dc_party", consignee_names, default_party=selected_party)
+
+    if st.button("🚀 Generate Delivery Challan", type="primary", key="dc_party_generate"):
+        if not fields["party_name"]:
+            st.warning("Please select a Party Name.")
+            return
+
+        final_request = DeliveryChallanRequest(
+            challan_type=fields["challan_type"],
+            challan_date=fields["challan_date"],
+            party_name=fields["party_name"],
+            vehicle_no=fields["vehicle_no"] or None,
+            ewaybill_no=fields["ewaybill_no"] or None,
+            hsn_code=fields["hsn_code"],
+            rounded_off=fields["rounded_off"],
+            remarks=fields["remarks"] or None,
+            items=st.session_state.dc_party_items,
+        )
+        _handle_challan_generation(service, final_request)
+
+
+# ══════════════════════════════════════════════════
+# MODE 4: Unused Coils (Year-End)
+# ══════════════════════════════════════════════════
+
+def _render_unused_coils_mode(service: DeliveryChallanService, consignee_names: list):
+    """Generate challan for coils that have not been used (Year-End feature)."""
+    st.markdown("### 📦 Unused Coils (Year-End)")
+    st.info("Shows coils from RM Inward that are not found in RM Used. Select coils to generate a Delivery Challan.")
+
+    if st.button("🔍 Fetch Unused Coils", key="dc_unused_fetch"):
+        with st.spinner("Cross-referencing RM Inward vs RM Used..."):
+            unused_df = service.get_unused_coils()
+            st.session_state.dc_unused_df = unused_df
+
+    if "dc_unused_df" not in st.session_state:
+        return
+
+    unused_df = st.session_state.dc_unused_df
+
+    if unused_df.empty:
+        st.success("🎉 No unused coils found — all coils have been used!")
+        return
+
+    st.markdown(f"#### Found **{len(unused_df)}** unused coil(s)")
+
+    # Display columns
+    display_cols = [c for c in ["Coil Number", "Grade", "Width", "Thk", "Coil Weight", "Coating", "Coil Supplier"] if c in unused_df.columns]
+    st.dataframe(unused_df[display_cols], use_container_width=True, hide_index=True)
+
+    # Select coils
+    coil_options = unused_df["Coil Number"].dropna().astype(str).str.strip().tolist()
+    selected_coils = st.multiselect(
+        "Select Coils for Challan",
+        options=coil_options,
+        key="dc_unused_selected",
+    )
+
+    if not selected_coils:
+        return
+
+    try:
+        request = service.build_request_from_coils(selected_coils)
+    except Exception as e:
+        st.error(f"❌ Error: {e}")
+        return
+
+    st.markdown("#### Auto-populated Coil Items")
+
+    if "dc_unused_items" not in st.session_state or st.session_state.get("dc_unused_last_selection") != selected_coils:
+        st.session_state.dc_unused_items = list(request.items)
+        st.session_state.dc_unused_last_selection = list(selected_coils)
+
+    st.session_state.dc_unused_items = _render_item_editor(
+        st.session_state.dc_unused_items, "dc_unused"
+    )
+
+    st.markdown("---")
+    st.markdown("#### Challan Details")
+    fields = _render_common_fields("dc_unused", consignee_names, default_party=request.party_name)
+
+    if st.button("🚀 Generate Delivery Challan", type="primary", key="dc_unused_generate"):
+        if not fields["party_name"]:
+            st.warning("Please select a Party Name.")
+            return
+
+        final_request = DeliveryChallanRequest(
+            challan_type=fields["challan_type"],
+            challan_date=fields["challan_date"],
+            party_name=fields["party_name"],
+            vehicle_no=fields["vehicle_no"] or None,
+            ewaybill_no=fields["ewaybill_no"] or None,
+            hsn_code=fields["hsn_code"],
+            rounded_off=fields["rounded_off"],
+            remarks=fields["remarks"] or "Year-End Unused Coils",
+            items=st.session_state.dc_unused_items,
+        )
+        _handle_challan_generation(service, final_request)
+
+
+# ══════════════════════════════════════════════════
+# Re-upload Missing Fields Excel
+# ══════════════════════════════════════════════════
+
+def _render_reupload_section(service: DeliveryChallanService):
+    """Allow users to re-upload a filled Missing Fields Excel to generate the PDF."""
+    with st.expander("📤 Re-upload Missing Fields Excel", expanded=False):
+        st.caption(
+            "If you previously downloaded a Missing Fields Excel, fill in the values "
+            "and upload it here to generate the PDF."
+        )
+        uploaded = st.file_uploader(
+            "Upload filled Excel",
+            type=["xlsx"],
+            key="dc_reupload_excel",
+        )
+
+        if uploaded:
+            try:
+                challan_df = pd.read_excel(uploaded, sheet_name="Challan Data")
+                items_df = pd.read_excel(uploaded, sheet_name="Coil Items")
+
+                if challan_df.empty or items_df.empty:
+                    st.error("The uploaded Excel is missing data in 'Challan Data' or 'Coil Items' sheets.")
+                    return
+
+                row = challan_df.iloc[0]
+
+                items = []
+                for _, item_row in items_df.iterrows():
+                    items.append(DeliveryChallanItem(
+                        coil_number=str(item_row.get("Coil Number", "")),
+                        description=str(item_row.get("Description", "")),
+                        grade=str(item_row.get("Grade", "")),
+                        width=float(item_row.get("Width", 0) or 0),
+                        thk=float(item_row.get("Thk", 0) or 0),
+                        coating=str(item_row.get("Coating", "")),
+                        weight_kg=float(item_row.get("Weight (kg)", 0) or 0),
+                        weight_mt=float(item_row.get("Weight (MT)", 0) or 0),
+                        nature_of_processing=str(item_row.get("Process", "Slitting")),
+                        hsn_code=str(item_row.get("HSN Code", "7208")),
+                        rate_per_mt=float(item_row.get("Rate per MT", 0) or 0),
+                        value=float(item_row.get("Value", 0) or 0),
+                    ))
+
+                request = DeliveryChallanRequest(
+                    challan_type=str(row.get("Challan Type", "job_work")),
+                    challan_date=pd.to_datetime(row.get("Challan Date", datetime.now().date())).date(),
+                    party_name=str(row.get("Party Name", "")),
+                    vehicle_no=str(row.get("Vehicle No", "")) or None,
+                    ewaybill_no=str(row.get("E-Waybill No", "")) or None,
+                    hsn_code=str(row.get("HSN Code", "7208")),
+                    rounded_off=float(row.get("Rounded Off", 0) or 0),
+                    remarks=str(row.get("Remarks", "")) or None,
+                    items=items,
+                )
+
+                st.success("✅ Excel parsed successfully! Review and generate:")
+                _handle_challan_generation(service, request)
+
+            except Exception as e:
+                st.error(f"❌ Failed to parse uploaded Excel: {e}")
+
+
+# ══════════════════════════════════════════════════
+# Main Page Render
+# ══════════════════════════════════════════════════
+
+def render_delivery_challan_form() -> None:
+    """Main render function for the Delivery Challan page."""
+    service = _get_service()
+    coil_numbers = _load_coil_numbers(service)
+    parties = _load_parties(service)
+    consignee_names = _load_consignees(service)
+
+    # Mode selector
+    mode = st.radio(
+        "Generation Mode",
+        options=["📝 Manual", "🔢 From Coil Number", "🏢 From Party", "📦 Unused Coils"],
+        horizontal=True,
+        key="dc_mode",
+        label_visibility="collapsed",
+    )
+
+    st.markdown("---")
+
+    if mode == "📝 Manual":
+        _render_manual_mode(service, consignee_names)
+    elif mode == "🔢 From Coil Number":
+        _render_coil_mode(service, consignee_names, coil_numbers)
+    elif mode == "🏢 From Party":
+        _render_party_mode(service, consignee_names, parties)
+    elif mode == "📦 Unused Coils":
+        _render_unused_coils_mode(service, consignee_names)
+
+    # Re-upload section (available in all modes)
+    st.markdown("---")
+    _render_reupload_section(service)

--- a/pages/pdf_generator.py
+++ b/pages/pdf_generator.py
@@ -4,6 +4,7 @@ import pandas as pd
 from pages.shared.utils import get_services
 from src.services import AppServices
 from datetime import datetime, timedelta
+from io import BytesIO
 
 # --- Top-level Cached Functions ---
 
@@ -33,6 +34,81 @@ def get_weight_receipts(_services: AppServices, party_name: str, start_date, end
     return _services.weight_receipt.get_weight_receipts_for_party_and_date_range(party_name, start_date, end_date)
 
 # --- Tab Rendering Functions ---
+
+def _prepare_challan_data(receipts_df):
+        items = []
+        grand_total_weight = 0
+
+        for _, receipt_row in receipts_df.iterrows():
+            line_items = []
+            receipt_total_weight = 0
+            receipt_total_deduction = float(receipt_row.get('Deduction', 0) or 0)
+
+            try:
+                designs = json.loads(receipt_row.get('DesignDetailsWithWeightsJSON', '[]') or '[]')
+            except:
+                designs = []
+
+            if isinstance(designs, list):
+                for design in designs:
+                    weight = float(design.get('actual_weight', 0) or 0)
+                    deduction = float(design.get('design_deduction', 0) or 0)
+
+                    if weight > 0:
+                        description = f"{design.get('width', '')} X {design.get('length', '')}"
+
+                        if design.get('mm_stack'):
+                            description += f" X {design.get('mm_stack', '')}"
+
+                        line_items.append({
+                            "description": description,
+                            "remark": design.get('remark', ''),
+                            "weight": weight,
+                            "deduction": deduction,
+                            "net_weight": weight - deduction,
+                            "hsn": receipt_row.get("HSN", ""),
+                            "rate": receipt_row.get("Rate", 0),
+                            "value": receipt_row.get("Value", 0)
+                        })
+                        receipt_total_weight += weight
+
+            if line_items:
+                grand_total_weight += receipt_total_weight
+
+                items.append({
+                    "job_no": receipt_row.get('JobCardNumber', ''),
+                    "po_no": receipt_row.get('PONumber', ''),
+                    "line_items": line_items,
+                    "summary": {
+                        "material": receipt_row.get('Material', ''),
+                        "sets": receipt_row.get('Sets', 0),
+                        "total_weight": receipt_total_weight,
+                        "total_deduction": receipt_total_deduction,
+                        "net_total_weight": receipt_total_weight - receipt_total_deduction
+                    }
+                })
+
+        if not items:
+            return None
+
+        challan_data = {
+            "challan_details": {
+                "to_customer": receipts_df.iloc[0].get('PartyName', ''),
+                "from_company": {
+                    "name": "AMBA ENTERPRISE LTD. (UNIT I)",
+                    "address": "S. No 132 , H.No 1/4/1, Premraj Ind Est, Shed No B-1/2/3/4, Dalvi Wadi, Nanded Phata, Dhairy, Pune 411041"
+                },
+                "challan_no": "UI",
+                "challan_date": datetime.now().strftime("%d/%m/%Y"),
+                "vehicle_no": ""
+            },
+            "items": items,
+            "grand_total_weight": grand_total_weight,
+            "receipts": receipts_df
+        }
+
+        return challan_data
+
 
 def render_coil_sticker_tab(services: AppServices):
     """Renders the UI for the Coil Sticker tab."""
@@ -122,169 +198,330 @@ def render_slitting_plan_tab(services: AppServices):
                 )
 
 def render_delivery_challan_tab(services: AppServices):
-    """Renders the UI for the Delivery Challan tab."""
+    """Enhanced Delivery Challan with Weight + Unused Coil modes"""
     st.header("Delivery Challan Generation")
-    
-    # --- Filters ---
-    col1, col2, col3 = st.columns(3)
-    with col1:
-        party_names = get_sales_order_dropdown_data(services).party_names
-        selected_party = st.selectbox("Select Party", options=[""] + party_names, key="dc_party")
-    with col2:
-        start_date = st.date_input("Start Date", datetime.now() - timedelta(days=30), key="dc_start_date")
-    with col3:
-        end_date = st.date_input("End Date", datetime.now(), key="dc_end_date")
 
-    if selected_party:
-        receipts = services.weight_receipt.get_weight_receipts_for_party_and_date_range(selected_party, start_date, end_date)
-        
-        if not receipts:
-            st.info("No Weight Receipts found for the selected party and date range.")
-            return
+    # =========================
+    # MODE SELECTION
+    # =========================
+    generation_mode = st.radio(
+        "Generation Mode",
+        ["⚖️ Weight Challan", "📦 Unused Coils"],
+        horizontal=True,
+        key="dc_mode"
+    )
 
-        df = pd.DataFrame(receipts)
-        
-        st.dataframe(
-            df,
-            on_select="rerun",
-            selection_mode="multi-row",
-            column_order=["WeightReceiptNumber", "Date", "JobCardNumber"],
-            hide_index=True,
-            key="dc_receipt_selection_df"
+    if generation_mode == "📦 Unused Coils":
+        sub_mode = st.radio(
+            "Select Method",
+            ["🔢 From Coil Number", "🏢 From Party"],
+            horizontal=True,
+            key="dc_sub_mode"
         )
 
-        selected_indices = st.session_state.dc_receipt_selection_df.selection.rows
-        selected_receipts = df.iloc[selected_indices]
+    st.markdown("---")
 
-        if not selected_receipts.empty:
-            st.write(f"{len(selected_receipts)} receipt(s) selected.")
-            if st.button("Generate Delivery Challan", key="generate_delivery_challan_pdf"):
-                
-                # --- Data Transformation Logic ---
-                def _prepare_challan_data(receipts_df):
-                    items = []
-                    grand_total_weight = 0
-                    for _, receipt_row in receipts_df.iterrows():
-                        is_core_building = receipt_row.get('WeightEntryType') == 'Building Core'
-                        line_items = []
-                        receipt_total_weight = 0
+    
+    # ============================================================
+    # 🟢 MODE 1 — ORIGINAL WEIGHT CHALLAN (UNCHANGED)
+    # ============================================================
+    if generation_mode == "⚖️ Weight Challan":
 
-                        if is_core_building:
-                            core_weight = float(receipt_row.get('TotalWeight') or 0)
-                            core_deduction = float(receipt_row.get('Deduction') or 0)
-                            if core_weight > 0:
-                                designs = json.loads(receipt_row.get('DesignDetailsWithWeightsJSON', '[]'))
-                                if isinstance(designs, list):
-                                    num_designs = len(designs)
-                                    for idx, design in enumerate(designs):
-                                        description = f"{design.get('width', '')} X {design.get('length', '')}"
-                                        if design.get('mm_stack'):
-                                            description += f" X {design.get('mm_stack', '')}"
-                                        
-                                        # Only show weight/deduction/net on the LAST item for Building Core group
-                                        is_last = (idx == num_designs - 1)
-                                        
-                                        line_items.append({
-                                            "description": description,
-                                            "remark": design.get('remark', ''),
-                                            "weight": core_weight if is_last else None,
-                                            "deduction": core_deduction if is_last else None,
-                                            "net_weight": (core_weight - core_deduction) if is_last else None
-                                        })
-                                receipt_total_weight = core_weight
-                                receipt_total_deduction = core_deduction
-                        else:
-                            # "Loose Strips" logic
-                            # Deduction Logic: 
-                            # If total 'Deduction' in receipt matches sum of 'design_deduction's, assign per design.
-                            # If total 'Deduction' exists but 'design_deduction's are 0, it's a bulk deduction (assign to last or distribute? Plan says show "-" in rows).
-                            # Wait, PDF Service will show "-" if I pass 0.
-                            # So I need to pass the actual 'design_deduction' if it exists.
-                            
-                            receipt_deduction_total = float(receipt_row.get('Deduction') or 0)
-                            calculated_deduction_sum = 0
-                            
-                            designs = json.loads(receipt_row.get('DesignDetailsWithWeightsJSON', '[]'))
-                            temp_items = []
-                            
-                            if isinstance(designs, list):
-                                for design in designs:
-                                    weight = float(design.get('actual_weight') or 0)
-                                    d_deduction = float(design.get('design_deduction') or 0)
-                                    calculated_deduction_sum += d_deduction
-                                    
-                                    if weight > 0:
-                                        remark = design.get('remark', '')
-                                        description = f"{design.get('width', '')} X {design.get('length', '')}"
-                                        if design.get('mm_stack'):
-                                            description += f" X {design.get('mm_stack', '')}"
-                                            
-                                        temp_items.append({
-                                            "description": description,
-                                            "remark": remark,
-                                            "weight": weight,
-                                            "deduction": d_deduction,  # Might be 0
-                                            "net_weight": weight - d_deduction
-                                        })
-                                        receipt_total_weight += weight
+        col1, col2, col3 = st.columns(3)
 
-                                # Handle Global Deduction case (User entered Total Deduction manually)
-                                # If calculated_sum (from rows) < receipt_deduction_total, it means there's a global override or extra deduction
-                                # In this case, we can't show it per row efficiently. 
-                                # BUT the PDF service iterates rows. 
-                                # If I pass deduction=0 for rows, they show "-".
-                                # Then I simply pass the Totals to the summary.
-                                # The Loop above sets 'deduction' to d_deduction (which is 0 in global case). Correct.
-                                
-                                line_items.extend(temp_items)
-                                receipt_total_deduction = receipt_deduction_total # Use the official total
+        with col1:
+            party_names = get_sales_order_dropdown_data(services).party_names
+            selected_party = st.selectbox("Select Party", options=[""] + party_names)
 
-                        
-                        if line_items:
-                            grand_total_weight += receipt_total_weight
-                            items.append({
-                                "job_no": receipt_row.get('JobCardNumber', ''),
-                                "po_no": receipt_row.get('PONumber', ''),
-                                "line_items": line_items,
-                                "summary": {
-                                    "material": receipt_row.get('Material', ''),
-                                    "sets": receipt_row.get('Sets', 0),
-                                    "total_weight": receipt_total_weight,
-                                    "total_deduction": receipt_total_deduction,
-                                    "net_total_weight": receipt_total_weight - receipt_total_deduction
-                                }
-                            })
+        with col2:
+            start_date = st.date_input("Start Date", datetime.now() - timedelta(days=30))
 
-                    if not items:
-                        return None
+        with col3:
+            end_date = st.date_input("End Date", datetime.now())
 
-                    challan_data = {
-                        "challan_details": {
-                            "to_customer": receipts_df.iloc[0].get('PartyName', ''),
-                            "from_company": {
-                                "name": "AMBA ENTERPRISE LTD. (UNIT I)",
-                                "address": "S. No 132 , H.No 1/4/1, Premraj Ind Est, Shed No B-1/2/3/4, Dalvi Wadi, Nanded Phata, Dhairy, Pune 411041"
-                            },
-                            "challan_no": "UI", # Placeholder
-                            "challan_date": datetime.now().strftime("%d/%m/%Y"),
-                            "vehicle_no": ""
-                        },
-                        "items": items,
-                        "grand_total_weight": grand_total_weight,
-                        "receipts": receipts_df
-                    }
-                    return challan_data
+        if selected_party:
+            receipts = services.weight_receipt.get_weight_receipts_for_party_and_date_range(
+                selected_party, start_date, end_date
+            )
 
-                challan_data = _prepare_challan_data(selected_receipts)
+            if not receipts:
+                st.info("No Weight Receipts found.")
+                return
 
-                with st.spinner("Generating PDF..."):
-                    pdf_output = services.pdf.generate_delivery_challan_pdf(challan_data)
+            df = pd.DataFrame(receipts)
+
+            st.dataframe(
+                df,
+                on_select="rerun",
+                selection_mode="multi-row",
+                hide_index=True,
+                key="dc_receipt_df"
+            )
+
+            selected_idx = st.session_state.get("dc_receipt_df", {}).get("selection", {}).get("rows", [])
+            selected_df = df.iloc[selected_idx]
+
+            if not selected_df.empty:
+                if st.button("Generate Delivery Challan"):
+
+                    challan_data = _prepare_challan_data(selected_df)
+
+                    if challan_data is None:
+                        st.error("No valid data to generate challan.")
+                        st.stop()
+
+                    pdf = services.pdf.generate_delivery_challan_pdf(challan_data)
+
                     st.download_button(
-                        label="Download Delivery Challan",
-                        data=pdf_output,
-                        file_name="delivery_challan.pdf",
-                        mime="application/pdf"
+                        "Download PDF",
+                        pdf,
+                        "delivery_challan.pdf",
+                        "application/pdf"
                     )
+
+    # ============================================================
+    # 🟢 MODE 2 — UNUSED COILS
+    # ============================================================
+    elif generation_mode == "📦 Unused Coils":
+
+        # =========================
+        # GET UNUSED COILS
+        # =========================
+        def get_unused_coils():
+            # Fetch already computed available coils (inward - used)
+            df = services.pdf.get_available_coils_for_sticker(
+                start_date=datetime.now() - timedelta(days=3650),
+                end_date=datetime.now()
+            )
+
+            df = pd.DataFrame(df)
+
+            if df.empty:
+                return df
+
+            # Ensure column exists
+            if "available_weight" in df.columns:
+                df["remaining_weight"] = df["available_weight"]
+            else:
+                df["remaining_weight"] = 0
+
+            # Keep only coils with remaining weight
+            df = df[df["remaining_weight"] > 0]
+
+            return df
+
+
+        df = get_unused_coils()
+
+        if df.empty:
+            st.warning("No unused coils available.")
+            return
+
+        # =========================
+        # SUB MODE FILTERING
+        # =========================
+        if sub_mode == "🔢 From Coil Number":
+
+            selected_coils = st.multiselect(
+                "Select Coil Number",
+                options=df["Coil Number"].unique()
+            )
+
+            if selected_coils:
+                df = df[df["Coil Number"].isin(selected_coils)]
+
+        elif sub_mode == "🏢 From Party":
+
+            col1, col2, col3 = st.columns(3)
+
+            with col1:
+                parties = df["coil_supplier"].dropna().unique()
+                selected_party = st.selectbox("Select Party", options=[""] + list(parties))
+
+            with col2:
+                start_date = st.date_input(
+                    "Start Date",
+                    datetime.now() - timedelta(days=30),
+                    key="unused_start_date"
+                )
+
+            with col3:
+                end_date = st.date_input(
+                    "End Date",
+                    datetime.now(),
+                    key="unused_end_date"
+                )
+
+            # Apply filters
+            if selected_party:
+                df = df[df["coil_supplier"] == selected_party]
+
+            # OPTIONAL: if your data has date column
+            if "inward_date" in df.columns:
+                df = df[
+                    (pd.to_datetime(df["inward_date"]) >= pd.to_datetime(start_date)) &
+                    (pd.to_datetime(df["inward_date"]) <= pd.to_datetime(end_date))
+                ]
+
+        # =========================
+        # DISPLAY
+        # =========================
+        display_cols = [col for col in ["Coil Number", "remaining_weight", "grade", "width", "coil_supplier"] if col in df.columns]
+
+        st.dataframe(
+            df[display_cols],
+            on_select="rerun",
+            selection_mode="multi-row",
+            hide_index=True,
+            key="unused_df"
+        )
+
+        # SAFE selection (same as weight challan)
+        selected_idx = st.session_state.get("unused_df", {}).get("selection", {}).get("rows", [])
+        selected_df = df.iloc[selected_idx]
+
+        if len(selected_idx) > 0:
+            st.write(f"{len(selected_idx)} coil(s) selected.")
+
+        # =========================
+        # EXCEL FALLBACK (IMPROVED)
+        # =========================
+        if not selected_df.empty:
+
+            # --- Step 1: Detect missing data properly ---
+            required_fields = {
+                "coil_supplier": "Party Name",
+                "remaining_weight": "Weight",
+                "width": "Width",
+            }
+
+            missing_data = []
+
+            for field, label in required_fields.items():
+                if field not in selected_df.columns:
+                    missing_data.append(label)
+                elif selected_df[field].isnull().any():
+                    missing_data.append(label)
+
+            # Optional business fields
+            optional_fields = ["rate", "hsn"]
+
+            for field in optional_fields:
+                if field not in selected_df.columns or selected_df[field].isnull().any():
+                    missing_data.append(field.upper())
+
+            # --- Step 2: If missing → generate structured Excel ---
+            uploaded = None
+            if missing_data:
+
+                st.warning(f"Missing fields: {', '.join(missing_data)}")
+
+                def generate_missing_excel(df):
+                    rows = []  # ✅ MUST be inside function
+
+                    for _, r in df.iterrows():
+                        rows.append({
+                            "Coil Number": r.get("Coil Number", ""),
+                            "Party Name": r.get("coil_supplier", ""),
+                            "Width": r.get("width", ""),
+                            "Weight (kg)": r.get("remaining_weight", ""),
+                            "HSN Code": r.get("hsn", ""),
+                            "Rate per MT": r.get("rate", ""),
+                            "Value": ""
+                        })
+
+                    export_df = pd.DataFrame(rows)  # ✅ inside function
+
+                    buffer = BytesIO()
+                    export_df.to_excel(buffer, index=False, sheet_name="Challan Data")
+
+                    return buffer.getvalue()
+
+                excel_bytes = generate_missing_excel(selected_df)
+
+                st.download_button(
+                    "Download Excel (Fill Missing Data)",
+                    excel_bytes,
+                    "delivery_challan_missing.xlsx"
+                )
+
+                uploaded = st.file_uploader("Upload Filled Excel", type=["xlsx"])
+
+            if uploaded:
+                filled_df = pd.read_excel(uploaded)
+
+                # Normalize columns
+                selected_df = filled_df.rename(columns={
+                    "Party Name": "coil_supplier",
+                    "Weight (kg)": "remaining_weight",
+                    "HSN Code": "hsn",
+                    "Rate per MT": "rate",
+                    "Coil Number": "Coil Number"
+                })
+
+                # 🔥 Ensure numeric conversion
+                selected_df["remaining_weight"] = pd.to_numeric(selected_df["remaining_weight"], errors="coerce")
+                selected_df["rate"] = pd.to_numeric(selected_df.get("rate", 0), errors="coerce")
+
+                # 🔥 Calculate value
+                selected_df["value"] = (
+                    selected_df["remaining_weight"] / 1000
+                ) * selected_df.get("rate", 0)
+
+                st.success("Excel uploaded successfully. Data updated.")
+
+
+        # =========================
+        # CONVERT → RECEIPT FORMAT
+        # =========================
+        def convert_to_receipt(df):
+            rows = []
+
+            for _, r in df.iterrows():
+                rows.append({
+                    "WeightReceiptNumber": "",
+                    "Date": datetime.now(),
+                    "JobCardNumber": r.get("Coil Number", ""),
+                    "WeightEntryType": "Loose",
+                    "TotalWeight": r["remaining_weight"],
+                    "Deduction": 0,
+                    "HSN": r.get("hsn", ""),
+                    "Rate": r.get("rate", 0),
+                    "Value": r.get("value", 0),
+                    "DesignDetailsWithWeightsJSON": json.dumps([{
+                        "width": r.get("width", ""),
+                        "length": "",
+                        "actual_weight": r["remaining_weight"],
+                        "design_deduction": 0,
+                        "remark": "Unused Coil"
+                    }]),
+                    "PartyName": r.get("coil_supplier", "")
+                })
+
+            return pd.DataFrame(rows)
+
+        # =========================
+        # GENERATE PDF
+        # =========================
+        if not selected_df.empty:
+            if st.button("Generate Delivery Challan"):
+
+                receipt_df = convert_to_receipt(selected_df)
+
+                challan_data = _prepare_challan_data(receipt_df)
+
+                if challan_data is None:
+                    st.error("No valid data to generate challan. Check selected rows.")
+                    st.stop()
+
+                pdf = services.pdf.generate_delivery_challan_pdf(challan_data)
+
+                st.download_button(
+                    "Download PDF",
+                    pdf,
+                    "delivery_challan.pdf",
+                    "application/pdf"
+                )
 
 def render_job_card_tab(services: AppServices):
     """Renders the UI for the Job Card tab."""
@@ -355,7 +592,7 @@ def render_weight_receipt_tab(services: AppServices):
             return
 
         df = pd.DataFrame(receipts)
-        
+            
         st.dataframe(
             df,
             on_select="rerun",
@@ -418,16 +655,16 @@ def render_pdf_generator_page():
             for cache_func in caches_to_clear:
                 cache_func.clear()
             st.toast(f"Cache for '{tab_to_clear}' tab cleared!")
-            
+                
             # Ensure the UI stays on the cleared tab
             if tab_to_clear in tab_names:
                 radio_index = tab_names.index(tab_to_clear)
-        else:
-            # If no specific tab is targeted, clear all for the page (optional)
-            for cache_list in TABS.values():
-                for cache_func in cache_list:
-                    cache_func.clear()
-            st.toast("Cache for PDF Generator page cleared!")
+            else:
+                # If no specific tab is targeted, clear all for the page (optional)
+                for cache_list in TABS.values():
+                    for cache_func in cache_list:
+                        cache_func.clear()
+                st.toast("Cache for PDF Generator page cleared!")
 
     # --- UI Rendering ---
 
@@ -442,7 +679,7 @@ def render_pdf_generator_page():
 
     # Render the content for the selected tab.
     if active_tab == "Coil Sticker":
-        render_coil_sticker_tab(services)
+        render_coil_sticker_tab(services)   
     elif active_tab == "Slitting Plan":
         render_slitting_plan_tab(services)
     elif active_tab == "Job Card":

--- a/pages/raw_material_inward_issue.py
+++ b/pages/raw_material_inward_issue.py
@@ -27,6 +27,13 @@ def _show_single_entry_confirmation_dialog(entries: list, data_service: RMInward
     display_df.columns = ['Coil Number', 'RM Type', 'Width (mm)', 'Thk (mm)', 'Weight (kg)', 'Supplier', 'Location']
     
     st.dataframe(display_df, use_container_width=True, hide_index=True)
+    #stock transfer
+    if "is_stock_transfer" in  df.columns and df["is_stock_transfer"].any():
+        stock_transfer_coils=df[df["is_stock_transfer"]==True]["coil_number"].tolist()
+        st.info(
+            "RM used entry will be also be created automatically for stock transfer coils:\n\n "
+            +"\n".join([f".st-{coil} (Machine : TAIIN transfer )" for coil in stock_transfer_coils])
+        )
     
     st.markdown("---")
     col1, col2 = st.columns(2)
@@ -157,9 +164,22 @@ def render_raw_material_inward_issue_form() -> None:
             st.selectbox("Coating", options=dropdowns.coatings, index=None, placeholder="Select or type a Coating", key="coating", accept_new_options=True)
             st.selectbox("Coil Supplier", options=dropdowns.suppliers, index=None, placeholder="Select or type a Supplier", key="supplier", accept_new_options=True)
             st.selectbox("Slit / Ready", options=["Ready", "Slit"], index=0, key="slit_ready")
-            st.number_input("Rate (per Kg)", min_value=0.0, step=0.01, format="%.2f", key="rate")
+            #stock transfer
+            # Stock Transfer
+            st.checkbox(
+                "Stock Transfer",
+                key="rm_is_stock_transfer"
+            )
 
-        st.selectbox("Coil Location", options=["AEL Pune", "TAIIN"], index=0, key="coil_location")
+            if st.session_state.get("rm_is_stock_transfer"):
+                st.date_input(
+                    "Date coil was originally sent to TAIIN",
+                    value=datetime.now().date(),
+                    max_value=datetime.now().date(),
+                    key="rm_transfer_date"
+                )
+            st.number_input("Rate (per Kg)", min_value=0.0, step=0.01, format="%.2f", key="rate")
+            st.selectbox("Coil Location", options=["AEL Pune", "TAIIN"], index=0, key="coil_location")
 
         if st.button("Add Coil to List"):
             validation_state = dict(st.session_state)
@@ -183,6 +203,9 @@ def render_raw_material_inward_issue_form() -> None:
                     "slit_ready": st.session_state.slit_ready,
                     "rate": st.session_state.rate,
                     "coil_location": st.session_state.coil_location,
+                    #stock transfer
+                    "is_stock_transfer": st.session_state.get("rm_is_stock_transfer", False),
+                    "transfer_date": st.session_state.get("rm_transfer_date", None),
                 }
                 st.session_state.rm_inward_entries.append(entry)
                 st.success("Coil added to the list.")
@@ -320,6 +343,11 @@ def render_raw_material_inward_issue_form() -> None:
             excel_cols = df.columns.tolist()
 
             st.markdown("##### Options")
+            st.checkbox(
+                "Stock Transfer",
+                key="bulk_is_stock_transfer",
+                value=False
+            )
             st.checkbox("Validate against Slitting Plan", key="validate_against_plan", value=False)
             
             if st.session_state.get("validate_against_plan"):
@@ -356,7 +384,7 @@ def render_raw_material_inward_issue_form() -> None:
                 "grade": "Grade", "thk": "Thk (mm)", "width": "Width (mm)", "coating": "Coating",
                 "coil_weight": "Coil Weight (kg)", "coil_supplier": "Coil Supplier",
                 "slit_ready": "Slit / Ready", "rate": "Rate",
-                "po_number": "PO Number (Optional)", "coil_location": "Coil Location"
+                "po_number": "PO Number (Optional)", "coil_location": "Coil Location" ,
             }
             if 'column_mapping' not in st.session_state:
                 st.session_state.column_mapping = {}
@@ -472,7 +500,11 @@ def render_raw_material_inward_issue_form() -> None:
                 options = {"user_email": user_email, "auto_generate_coil": auto_generate_coil, "group_by_col": group_by_col}
                 existing_coils = set(c.lower() for c in dropdowns.coil_numbers)
                 valid_requests, failed_records = data_service.process_bulk_upload_df(processing_df, mapping, options, existing_coils)
-                
+                # Apply stock transfer flag from frontend
+                if st.session_state.get("bulk_is_stock_transfer"):
+                    for req in valid_requests:
+                        req.is_stock_transfer = True
+
                 # Store processed records in session state for the dialog to use
                 st.session_state.pending_valid_requests = valid_requests
                 st.session_state.pending_failed_records = failed_records

--- a/src/data_entry/models/delivery_challan_models.py
+++ b/src/data_entry/models/delivery_challan_models.py
@@ -1,0 +1,78 @@
+from pydantic import BaseModel, validator
+from datetime import date
+from typing import List, Optional, Literal
+import json
+
+
+class DeliveryChallanItem(BaseModel):
+    coil_number: str
+    description: str
+    grade: str
+    width: float
+    thk: float
+    coating: str
+    weight_kg: float
+    weight_mt: float
+    nature_of_processing: str
+    hsn_code: str
+    rate_per_mt: float
+    value: float
+
+
+class DeliveryChallanRequest(BaseModel):
+    challan_type: Literal["job_work", "return"]
+    challan_date: date
+    party_name: str = "TAIIN STEEL FAB & INFRA PVT LTD"
+    vehicle_no: Optional[str] = None
+    ewaybill_no: Optional[str] = None
+    hsn_code: str = ""
+    rounded_off: float = 0.0
+    remarks: Optional[str] = None
+    items: List[DeliveryChallanItem]
+
+    @validator("items")
+    def must_have_items(cls, v):
+        if len(v) == 0:
+            raise ValueError("At least one coil item is required")
+        return v
+
+
+class MissingFieldResult(BaseModel):
+    """Result of missing field validation for a challan request."""
+    field_name: str
+    display_name: str
+    source: str  # e.g. "Consignee Master", "RM Inward", "User Input"
+    is_missing: bool = True
+
+
+class DeliveryChallanRecord(BaseModel):
+    challan_number: str
+    challan_date: date
+    challan_type: str
+    party_name: str
+    vehicle_no: Optional[str]
+    ewaybill_no: Optional[str]
+    hsn_code: str
+    total_weight_mt: float
+    total_value: float
+    rounded_off: float
+    remarks: Optional[str]
+    status: str = "Finalized"
+    coils_json: str
+
+    def to_list(self) -> list:
+        return [
+            self.challan_number,
+            str(self.challan_date),
+            self.challan_type,
+            self.party_name,
+            self.vehicle_no or "",
+            self.ewaybill_no or "",
+            self.hsn_code,
+            self.total_weight_mt,
+            self.total_value,
+            self.rounded_off,
+            self.remarks or "",
+            self.status,
+            self.coils_json,
+        ]

--- a/src/data_entry/models/rm_inward_models.py
+++ b/src/data_entry/models/rm_inward_models.py
@@ -22,7 +22,10 @@ class RMInwardIssueRequest(BaseModel):
     slit_ready: str = Field(default="Ready", description="Slit/Ready")
     rate: float = Field(default=0.0, ge=0, description="Rate")
     coil_location: str = Field(..., description="Coil Location")
-
+    is_stock_transfer: bool = False
+    transfer_date: Optional[date] = None
+    transfer_to: Optional[str] = None
+    
     @field_validator("coil_weight", "thk", "width")
     @classmethod
     def validate_positive_numbers(cls, v):

--- a/src/data_entry/models/rm_used_models.py
+++ b/src/data_entry/models/rm_used_models.py
@@ -30,6 +30,10 @@ class RMUsedRecord(BaseModel):
             self.machine,
             self.remarks,
             self.no_of_boxes,
+            "",
+            "",
+            "",
+            "",
         ]
 
 class DropdownData(BaseModel):

--- a/src/data_entry/service/delivery_challan_service.py
+++ b/src/data_entry/service/delivery_challan_service.py
@@ -1,0 +1,649 @@
+from typing import List, Dict, Optional, Tuple
+import json
+import io
+import pandas as pd
+from fpdf import FPDF
+from num2words import num2words
+from datetime import datetime
+from openpyxl import Workbook
+from openpyxl.styles import Font, PatternFill, Alignment, Border, Side
+
+from src.shared.utils.logger_config import setup_logger
+from src.shared.integrations.google_drive_service import GoogleDriveService
+from src.data_entry.models.delivery_challan_models import (
+    DeliveryChallanRequest,
+    DeliveryChallanRecord,
+    DeliveryChallanItem,
+    MissingFieldResult,
+)
+
+import config
+
+
+class DeliveryChallanPDF(FPDF):
+    def header(self):
+        pass
+
+    def footer(self):
+        pass
+
+
+class DeliveryChallanService:
+    def __init__(self):
+        self.logger = setup_logger(__name__)
+        self.google_service = GoogleDriveService()
+        self._consignees_cache = None
+        self._rm_inward_cache = None
+
+    # ──────────────────────────────────────────
+    # Consignee Master
+    # ──────────────────────────────────────────
+
+    def get_consignees(self) -> List[Dict]:
+        if self._consignees_cache is not None:
+            return self._consignees_cache
+
+        df = self.google_service.get_worksheet_data(
+            config.settings.api.google_sheets_id,
+            config.CONSIGNEE_MASTER_SHEET,
+        )
+
+        consignees = df.to_dict(orient="records")
+
+        self._consignees_cache = consignees
+        return consignees
+
+    # ──────────────────────────────────────────
+    # RM Inward Data Access
+    # ──────────────────────────────────────────
+
+    def get_rm_inward_data(self) -> pd.DataFrame:
+        """Fetch RM Inward sheet data (header_row=3 to match existing convention)."""
+        if self._rm_inward_cache is not None:
+            return self._rm_inward_cache
+
+        df = self.google_service.get_worksheet_data(
+            config.settings.api.google_sheets_id,
+            config.RM_INWARD_ISSUE_SHEET,
+            header_row=3,
+        )
+
+        df.columns = df.columns.str.strip()
+        self._rm_inward_cache = df
+        return df
+
+    def get_coil_numbers(self) -> List[str]:
+        """Get all unique coil numbers from RM Inward sheet."""
+        df = self.get_rm_inward_data()
+
+        if "Coil No" not in df.columns:
+            return []
+
+        return (
+            df["Coil No"]
+            .dropna()
+            .astype(str)
+            .str.strip()
+            .loc[lambda s: s != ""]
+            .unique()
+            .tolist()
+        )
+
+    def get_rm_parties(self) -> List[str]:
+        """Get all unique supplier/party names from RM Inward sheet."""
+        df = self.get_rm_inward_data()
+
+        col = "Coil Supplier" if "Coil Supplier" in df.columns else "Supplier"
+        if col not in df.columns:
+            return []
+
+        return sorted(
+            df[col]
+            .dropna()
+            .astype(str)
+            .str.strip()
+            .loc[lambda s: s != ""]
+            .unique()
+            .tolist()
+        )
+
+    def get_coils_by_party(self, party: str) -> List[str]:
+        """Get coil numbers filtered by a specific party/supplier."""
+        df = self.get_rm_inward_data()
+
+        col = "Coil Supplier" if "Coil Supplier" in df.columns else "Supplier"
+        if col not in df.columns or "Coil No" not in df.columns:
+            return []
+
+        filtered = df[
+            df[col].astype(str).str.strip().str.lower()
+            == str(party).strip().lower()
+        ]
+        return (
+            filtered["Coil No"]
+            .dropna()
+            .astype(str)
+            .str.strip()
+            .loc[lambda s: s != ""]
+            .tolist()
+        )
+
+    def _coil_row_to_item(self, row: pd.Series) -> DeliveryChallanItem:
+        """Convert one RM Inward row to a DeliveryChallanItem."""
+        weight_kg = float(row.get("Coil Weight", 0) or 0)
+        weight_mt = weight_kg / 1000
+
+        return DeliveryChallanItem(
+            coil_number=str(row.get("Coil No", "")),
+            description=str(row.get("Grade", "")),
+            grade=str(row.get("Grade", "")),
+            width=float(row.get("Width", 0) or 0),
+            thk=float(row.get("Thk", 0) or 0),
+            coating=str(row.get("Coating", "")),
+            weight_kg=weight_kg,
+            weight_mt=weight_mt,
+            nature_of_processing="Slitting",
+            hsn_code="7208",
+            rate_per_mt=0,
+            value=0,
+        )
+
+    def _get_party_from_row(self, row: pd.Series) -> str:
+        """Extract the supplier/party name from an RM Inward row."""
+        col = "Coil Supplier" if "Coil Supplier" in row.index else "Supplier"
+        return str(row.get(col, ""))
+
+    def build_request_from_coils(
+    self,
+    coil_numbers: List[str],
+    challan_type: str = "job_work",
+    party_name: str = "",
+    vehicle_no: str = "",
+    ewaybill_no: str = "",
+    hsn_code: str = "7208",
+    rounded_off: float = 0.0,   
+    remarks: str = "",
+    ) -> DeliveryChallanRequest:
+        """Build a DeliveryChallanRequest from RM Inward using remaining weight logic."""
+
+        df = self.get_rm_inward_data()
+
+        # --- Load RM Used once ---
+        used_df = self.google_service.get_worksheet_data(
+            config.settings.api.google_sheets_id,
+            config.RM_USED_SHEET,
+        )
+
+        used_df.columns = [str(col).strip() for col in used_df.columns]
+
+        used_df["Coil No"] = used_df["Coil No"].astype(str).str.strip()
+
+        # detect correct weight column
+
+        if "Coil Weight" in used_df.columns:
+            used_weight_col = "Coil Weight"
+        elif "Weight" in used_df.columns:
+            used_weight_col = "Weight"
+        elif "weight_kg" in used_df.columns:
+            used_weight_col = "weight_kg"
+        else:
+            raise ValueError(f"No valid weight column in RM Used: {used_df.columns.tolist()}")
+
+        used_df[used_weight_col] = pd.to_numeric(
+            used_df[used_weight_col], errors="coerce"
+        ).fillna(0)
+
+        # aggregate used weight
+        used_agg = (
+            used_df.groupby("Coil No")[used_weight_col]
+            .sum()
+            .to_dict()
+        )
+
+        items = []
+        detected_party = party_name
+
+        for coil in coil_numbers:
+            match = df[
+                df["Coil No"].astype(str).str.strip()
+                == str(coil).strip()
+            ]
+
+            if match.empty:
+                raise ValueError(f"Coil '{coil}' not found in RM Inward sheet")
+
+            row = match.iloc[0]
+
+            inward_weight = float(row.get("Coil Weight", 0))
+            used_weight = float(used_agg.get(str(coil).strip(), 0))
+
+            remaining_weight = inward_weight - used_weight
+
+            # skip fully used
+            if remaining_weight <= 0:
+                continue
+
+            row = row.copy()
+            row["Coil Weight"] = remaining_weight
+
+            items.append(self._coil_row_to_item(row))
+
+            if not detected_party:
+                detected_party = self._get_party_from_row(row)
+
+        if not items:
+            raise ValueError("All selected coils are fully used.")
+
+        return DeliveryChallanRequest(
+        challan_type=challan_type,
+        challan_date=datetime.now().date(),
+        party_name=detected_party or "TAIIN STEEL FAB & INFRA PVT LTD",
+        vehicle_no=vehicle_no or None,
+        ewaybill_no=ewaybill_no or None,
+        hsn_code=hsn_code,
+        rounded_off=rounded_off,
+        remarks=remarks or "Generated from RM Inward",
+        items=items,
+        )
+
+    # ──────────────────────────────────────────
+    # Unused Coils
+    # ──────────────────────────────────────────
+
+    def get_unused_coils(self):
+
+        # --- Load RM Inward ---
+        inward_df = self.google_service.get_worksheet_data(
+        config.settings.api.google_sheets_id,
+        config.RM_INWARD_ISSUE_SHEET,
+        )
+        inward_df.columns = [str(col).strip() for col in inward_df.columns]
+        # --- Load RM Used ---
+        used_df = self.google_service.get_worksheet_data(
+        config.settings.api.google_sheets_id,
+        config.RM_USED_SHEET,
+            )
+        used_df.columns = [str(col).strip() for col in used_df.columns]
+        # --- Normalize column names ---
+        inward_df["Coil No"] = inward_df["Coil No"].astype(str).str.strip()
+        used_df["Coil No"] = used_df["Coil No"].astype(str).str.strip()
+        # --- Handle weight columns safely ---
+        if "Coil Weight" in inward_df.columns:
+            inward_weight_col = "Coil Weight"
+        elif "Weight" in inward_df.columns:
+            inward_weight_col = "Weight"
+        else:
+            raise ValueError(f"No valid weight column in RM Inward: {inward_df.columns.tolist()}")
+
+        inward_df[inward_weight_col] = pd.to_numeric(
+            inward_df[inward_weight_col], errors="coerce"
+        ).fillna(0)
+        # IMPORTANT: Change this if RM Used column name is different
+        used_weight_col = "Weight"
+        if "Weight" not in used_df.columns:
+            used_weight_col = "weight_kg"
+        used_df[used_weight_col] = pd.to_numeric(used_df[used_weight_col], errors="coerce").fillna(0)
+        # --- Aggregate RM Used ---
+        used_agg = (
+            used_df.groupby("Coil No")[used_weight_col]
+            .sum()
+            .reset_index()
+            .rename(columns={used_weight_col: "Used Weight"})
+        )
+        # --- Merge inward + used ---
+        merged = inward_df.merge(
+            used_agg,
+            on="Coil No",
+            how="left"
+        )
+        merged["Used Weight"] = merged["Used Weight"].fillna(0)
+        # --- Calculate remaining ---
+        merged["Remaining Weight"] = merged[inward_weight_col] - merged["Used Weight"]
+        # --- Keep only usable coils ---
+        unused_df = merged[merged["Remaining Weight"] > 0].copy()
+        # --- Replace weight with remaining ---
+        unused_df[inward_weight_col] = unused_df["Remaining Weight"]
+        # Optional: rename for UI clarity
+        unused_df.rename(columns={"Weight": "Remaining Weight"}, inplace=True)
+
+        return unused_df
+
+    # ──────────────────────────────────────────
+    # Missing Data Handling
+    # ──────────────────────────────────────────
+
+    def check_missing_fields(
+        self, request: DeliveryChallanRequest
+    ) -> List[MissingFieldResult]:
+        """Check a challan request for missing critical data needed for PDF generation."""
+        missing = []
+
+        # Check user-input fields
+        if not request.vehicle_no or not request.vehicle_no.strip():
+            missing.append(MissingFieldResult(
+                field_name="vehicle_no",
+                display_name="Vehicle Number",
+                source="User Input",
+            ))
+
+        if not request.ewaybill_no or not request.ewaybill_no.strip():
+            missing.append(MissingFieldResult(
+                field_name="ewaybill_no",
+                display_name="E-Waybill Number",
+                source="User Input",
+            ))
+
+        # Check consignee data
+        consignees = self.get_consignees()
+        consignee = None
+        for c in consignees:
+            if c.get("Party Name", "").strip().lower() == request.party_name.strip().lower():
+                consignee = c
+                break
+
+        if consignee is None:
+            missing.append(MissingFieldResult(
+                field_name="party_name",
+                display_name="Party not found in Consignee Master",
+                source="Consignee Master",
+            ))
+        else:
+            consignee_fields = {
+                "Address Line 1": "Dispatch Address Line 1",
+                "Address Line 2": "Dispatch Address Line 2",
+                "GSTIN": "GSTIN",
+                "State": "State",
+                "State Code": "State Code",
+                "Dispatch From Address": "Dispatch From Address",
+            }
+            for field, display in consignee_fields.items():
+                val = consignee.get(field, "")
+                if not val or not str(val).strip():
+                    missing.append(MissingFieldResult(
+                        field_name=field,
+                        display_name=display,
+                        source="Consignee Master",
+                    ))
+
+        return missing
+
+    def generate_missing_excel(
+        self,
+        request: DeliveryChallanRequest,
+        missing_fields: List[MissingFieldResult],
+    ) -> bytes:
+        """Generate an Excel file listing missing fields for the user to fill in."""
+        wb = Workbook()
+
+        # --- Missing Fields Sheet ---
+        ws_missing = wb.active
+        ws_missing.title = "Missing Fields"
+
+        header_font = Font(bold=True, color="FFFFFF", size=11)
+        header_fill = PatternFill(start_color="4472C4", end_color="4472C4", fill_type="solid")
+        thin_border = Border(
+            left=Side(style="thin"),
+            right=Side(style="thin"),
+            top=Side(style="thin"),
+            bottom=Side(style="thin"),
+        )
+
+        headers = ["Field Name", "Display Name", "Source", "Value (Fill This)"]
+        for col, h in enumerate(headers, 1):
+            cell = ws_missing.cell(row=1, column=col, value=h)
+            cell.font = header_font
+            cell.fill = header_fill
+            cell.alignment = Alignment(horizontal="center")
+            cell.border = thin_border
+
+        for row_idx, mf in enumerate(missing_fields, 2):
+            ws_missing.cell(row=row_idx, column=1, value=mf.field_name).border = thin_border
+            ws_missing.cell(row=row_idx, column=2, value=mf.display_name).border = thin_border
+            ws_missing.cell(row=row_idx, column=3, value=mf.source).border = thin_border
+            value_cell = ws_missing.cell(row=row_idx, column=4, value="")
+            value_cell.border = thin_border
+            value_cell.fill = PatternFill(start_color="FFFFCC", end_color="FFFFCC", fill_type="solid")
+
+        # Auto-fit column widths
+        for col in ws_missing.columns:
+            max_length = max(len(str(cell.value or "")) for cell in col)
+            ws_missing.column_dimensions[col[0].column_letter].width = max_length + 4
+
+        # --- Challan Data Sheet ---
+        ws_data = wb.create_sheet("Challan Data")
+        data_headers = [
+            "Challan Type", "Challan Date", "Party Name", "Vehicle No",
+            "E-Waybill No", "HSN Code", "Rounded Off", "Remarks",
+        ]
+        for col, h in enumerate(data_headers, 1):
+            cell = ws_data.cell(row=1, column=col, value=h)
+            cell.font = header_font
+            cell.fill = header_fill
+            cell.alignment = Alignment(horizontal="center")
+            cell.border = thin_border
+
+        data_values = [
+            request.challan_type,
+            str(request.challan_date),
+            request.party_name,
+            request.vehicle_no or "",
+            request.ewaybill_no or "",
+            request.hsn_code,
+            request.rounded_off,
+            request.remarks or "",
+        ]
+        for col, v in enumerate(data_values, 1):
+            ws_data.cell(row=2, column=col, value=v).border = thin_border
+
+        # --- Items Sheet ---
+        ws_items = wb.create_sheet("Coil Items")
+        item_headers = [
+            "Coil No", "Description", "Grade", "Width", "Thk",
+            "Coating", "Weight (kg)", "Weight (MT)", "Process",
+            "HSN Code", "Rate per MT", "Value",
+        ]
+        for col, h in enumerate(item_headers, 1):
+            cell = ws_items.cell(row=1, column=col, value=h)
+            cell.font = header_font
+            cell.fill = header_fill
+            cell.alignment = Alignment(horizontal="center")
+            cell.border = thin_border
+
+        for row_idx, item in enumerate(request.items, 2):
+            values = [
+                item.coil_number, item.description, item.grade,
+                item.width, item.thk, item.coating,
+                item.weight_kg, item.weight_mt, item.nature_of_processing,
+                item.hsn_code, item.rate_per_mt, item.value,
+            ]
+            for col, v in enumerate(values, 1):
+                ws_items.cell(row=row_idx, column=col, value=v).border = thin_border
+
+        buf = io.BytesIO()
+        wb.save(buf)
+        return buf.getvalue()
+
+    # ──────────────────────────────────────────
+    # Challan Number Generation
+    # ──────────────────────────────────────────
+
+    def generate_challan_number(self) -> str:
+        df = self.google_service.get_worksheet_data(
+            config.settings.api.google_sheets_id,
+            config.DELIVERY_CHALLAN_SHEET,
+        )
+
+        numbers = []
+
+        if "Challan Number" in df.columns:
+            for val in df["Challan Number"].dropna():
+                try:
+                    num = int(val.split("/")[1])
+                    numbers.append(num)
+                except Exception:
+                    continue
+
+        next_num = max(numbers, default=0) + 1
+
+        return f"F/{next_num:03}/{config.FINANCIAL_YEAR}"
+
+    # ──────────────────────────────────────────
+    # Create Challan (Save to Google Sheets)
+    # ──────────────────────────────────────────
+
+    def create_delivery_challan(
+        self, request: DeliveryChallanRequest
+    ) -> str:
+
+        challan_number = self.generate_challan_number()
+
+        total_weight_mt = sum(item.weight_mt for item in request.items)
+        total_value = sum(item.value for item in request.items)
+
+        record = DeliveryChallanRecord(
+            challan_number=challan_number,
+            challan_date=request.challan_date,
+            challan_type=request.challan_type,
+            party_name=request.party_name,
+            vehicle_no=request.vehicle_no,
+            ewaybill_no=request.ewaybill_no,
+            hsn_code=request.hsn_code,
+            total_weight_mt=total_weight_mt,
+            total_value=total_value,
+            rounded_off=request.rounded_off,
+            remarks=request.remarks,
+            coils_json=json.dumps(
+                [item.dict() for item in request.items]
+            ),
+        )
+
+        self.google_service.insert_row_before_last(
+            config.settings.api.google_sheets_id,
+            config.DELIVERY_CHALLAN_SHEET,
+            [record.to_list()],
+        )
+
+        return challan_number
+
+    # ──────────────────────────────────────────
+    # PDF Generation (Existing — Preserved)
+    # ──────────────────────────────────────────
+
+    def generate_challan_pdf(self, challan_number: str) -> bytes:
+
+        df = self.google_service.get_worksheet_data(
+            config.settings.api.google_sheets_id,
+            config.DELIVERY_CHALLAN_SHEET,
+        )
+
+        df.columns = df.columns.astype(str).str.strip()
+
+        record = df[df["Challan Number"] == challan_number].iloc[0]
+        items = json.loads(record["Coils JSON"])
+
+        challan_date = datetime.strptime(
+        str(record["Challan Date"]), "%Y-%m-%d"
+        ).strftime("%d/%m/%Y")
+
+        pdf = FPDF()
+        pdf.set_auto_page_break(False)
+
+        # 3 COPIES
+        for _ in range(3):
+
+            pdf.add_page()
+            pdf.set_font("Arial", "", 10)
+
+            # ===== HEADER =====
+            pdf.cell(0, 6, f"To M/S.: {record['Party Name']}", ln=True)
+
+            pdf.ln(2)
+
+            pdf.set_font("Arial", "B", 10)
+            pdf.cell(0, 6, "AMBA ENTERPRISE LTD. (UNIT I)", ln=True)
+
+            pdf.set_font("Arial", "", 9)
+            pdf.multi_cell(0, 5,
+                "S. No 132 , H.No 1/4/1, Premraj Ind Est,\n"
+                "Shed No B-1/2/3/4, Dalvi Wadi,\n"
+                "Nanded Phata, Dhairy, Pune 411041"
+            )
+
+            pdf.ln(3)
+
+            # ===== TITLE =====
+            pdf.set_font("Arial", "B", 11)
+            pdf.cell(0, 6, "Delivery Challan/ Receipt Inspection Report", ln=True)
+
+            pdf.ln(3)
+
+            # ===== DETAILS =====
+            pdf.set_font("Arial", "", 9)
+            pdf.cell(0, 5, f"Challan No: {challan_number}", ln=True)
+            pdf.cell(0, 5, f"Challan Date: {challan_date}", ln=True)
+            pdf.cell(0, 5, f"Vehicle No: {record['Vehicle No'] or ''}", ln=True)
+
+            pdf.ln(4)
+
+            # ===== TABLE =====
+            pdf.set_font("Arial", "B", 9)
+
+            headers = ["Job No", "P O No", "Particulars", "Gross Wt", "Deduction", "Net Wt"]
+            widths = [30, 30, 40, 25, 25, 25]
+
+            for h, w in zip(headers, widths):
+                pdf.cell(w, 6, h, border=1)
+            pdf.ln()
+
+            pdf.set_font("Arial", "", 9)
+
+            total_gross = 0
+            total_net = 0
+
+            for i, item in enumerate(items, start=1):
+
+                gross = item.get("weight_mt", 0)
+            net = gross
+
+            total_gross += gross
+            total_net += net
+
+            pdf.cell(30, 6, str(10000 + i), border=1)
+            pdf.cell(30, 6, f"{item.get('width', '')}", border=1)
+            pdf.cell(40, 6, item.get("description", ""), border=1)
+            pdf.cell(25, 6, f"{gross:.2f}", border=1)
+            pdf.cell(25, 6, "-", border=1)
+            pdf.cell(25, 6, f"{net:.2f}", border=1)
+            pdf.ln()
+
+            # ===== TOTAL =====
+            pdf.set_font("Arial", "B", 9)
+            pdf.cell(100, 6, "Total", border=1)
+            pdf.cell(25, 6, f"{total_gross:.3f}", border=1)
+            pdf.cell(25, 6, "0.000", border=1)
+            pdf.cell(25, 6, f"{total_net:.3f}", border=1)
+            pdf.ln()
+
+            pdf.ln(5)
+
+            # ===== FOOTER =====
+            pdf.set_font("Arial", "", 9)
+
+            pdf.cell(0, 5, "Note:", ln=True)
+            pdf.cell(0, 5, "E. & O.E.", ln=True)
+
+            pdf.multi_cell(0, 5,
+            "Mentioned product(s) are received in the good Condition at our side."
+            )
+
+            pdf.ln(8)
+
+            pdf.cell(90, 5, "Receiver's Signature", ln=0)
+            pdf.cell(90, 5, "For AMBA ENTERPRISE LTD. (UNIT I)", ln=True)
+
+            pdf.ln(8)
+
+            pdf.cell(90, 5, "Prepared By", ln=0)
+            pdf.cell(90, 5, "Verified By", ln=True)
+
+        return bytes(pdf.output(dest="S"))

--- a/src/data_entry/service/rm_inward_service.py
+++ b/src/data_entry/service/rm_inward_service.py
@@ -12,6 +12,8 @@ import json
 import gspread
 import logging
 from datetime import datetime
+from src.data_entry.service.rm_used_service import RMUsedService
+from src.data_entry.models.rm_used_models import RMUsedRequest
 
 # Configure logger
 logger = setup_logger(__name__)
@@ -31,7 +33,7 @@ class RMInwardService:
         if self._dropdown_df is None:
             try:
                 self._dropdown_df = self.google_service.get_worksheet_data(
-                    self.spreadsheet_id, "RM inward_Issue format", header_row=3
+                    self.spreadsheet_id, config.RM_INWARD_SHEET, header_row=3
                 )
             except Exception as e:
                 logger.error(f"Error loading dropdown data: {str(e)}")
@@ -125,8 +127,20 @@ class RMInwardService:
                 data_rows.append(record.to_list())
 
             success = self.google_service.insert_row_before_last(
-                self.spreadsheet_id, "RM inward_Issue format", data_rows
+                self.spreadsheet_id, config.RM_INWARD_SHEET, data_rows
             )
+
+            if success:
+                for request in requests:
+                    logger.info(f"DEBUG: coil={request.coil_number}, is_stock_transfer={request.is_stock_transfer}")  # ✅ ADD THIS
+                    if request.is_stock_transfer:
+                        logger.info(f"DEBUG: Triggering RM Used for {request.coil_number}")  # ✅ ADD THIS
+                        try:
+                            self._create_stock_transfer_rm_used(request)
+                        except Exception as e:
+                            logger.error(
+                                f"Stock transfer RM Used creation failed for coil {request.coil_number}: {str(e)}"
+                            )
 
             if success:
                 logger.info(
@@ -148,7 +162,7 @@ class RMInwardService:
                 return []
 
             df = self.google_service.get_worksheet_data(
-                self.spreadsheet_id, "RM inward_Issue format", header_row=3
+                self.spreadsheet_id, config.RM_INWARD_SHEET, header_row=3
             )
 
             if df.empty:
@@ -172,7 +186,7 @@ class RMInwardService:
 
             try:
                 headers = self.google_service.get_worksheet_headers(
-                    self.spreadsheet_id, "RM inward_Issue format"
+                    self.spreadsheet_id, config.RM_INWARD_SHEET
                 )
 
                 if not headers:
@@ -426,3 +440,29 @@ class RMInwardService:
                     }
                 )
         return valid_requests, failed_records
+    
+    def _create_stock_transfer_rm_used(self, request: RMInwardIssueRequest):
+        """Creates an RM Used entry for stock transfer"""
+        try:
+            rm_used_service = RMUsedService()
+
+            rm_used_request = RMUsedRequest(
+                rm_used_date=request.transfer_date or request.rm_receipt_date,
+                card_no=f"ST-{request.coil_number}",
+            coil_no=request.coil_number,
+            weight=request.coil_weight,
+            machine="TAIIN Transfer",
+            remarks="Stock Transfer - Returned without slitting",
+            no_of_boxes=0,
+            )
+
+            success = rm_used_service.create_rm_used(rm_used_request)
+
+            print(f"DEBUG: RM Used success = {success}")
+
+            if not success:
+                raise Exception("RM Used creation failed")
+
+        except Exception as e:
+            print(f"DEBUG ERROR: {e}")
+            raise

--- a/src/services.py
+++ b/src/services.py
@@ -7,6 +7,7 @@ from src.pdf_generator.service.pdf_service import PDFService
 from src.data_entry.service.weight_receipt_service import WeightReceiptService
 from src.slitting_plan.service.slitting_plan_service import SlittingPlanService
 from src.data_entry.service.rm_inward_service import RMInwardService
+from src.data_entry.service.delivery_challan_service import DeliveryChallanService
 
 class AppServices:
     """A container for all application services."""
@@ -17,12 +18,14 @@ class AppServices:
         weight_receipt: WeightReceiptService,
         slitting_plan: SlittingPlanService,
         rm_inward: RMInwardService,
+        delivery_challan: DeliveryChallanService,
     ):
         self.sales_order = sales_order
         self.pdf = pdf
         self.weight_receipt = weight_receipt
         self.slitting_plan = slitting_plan
         self.rm_inward = rm_inward
+        self.delivery_challan = delivery_challan
 
 def create_services() -> AppServices:
     """
@@ -39,6 +42,7 @@ def create_services() -> AppServices:
     weight_receipt_service = WeightReceiptService()
     slitting_plan_service = SlittingPlanService()
     rm_inward_service = RMInwardService()
+    delivery_challan_service = DeliveryChallanService()
 
     # Return the container with all services
     return AppServices(
@@ -47,4 +51,5 @@ def create_services() -> AppServices:
         weight_receipt=weight_receipt_service,
         slitting_plan=slitting_plan_service,
         rm_inward=rm_inward_service,
+        delivery_challan=delivery_challan_service,
     )

--- a/test_delivery_challan.py
+++ b/test_delivery_challan.py
@@ -1,0 +1,35 @@
+from datetime import date
+
+from src.data_entry.service.delivery_challan_service import DeliveryChallanService
+from src.data_entry.models.delivery_challan_models import (
+    DeliveryChallanRequest,
+    DeliveryChallanItem,
+)
+
+service = DeliveryChallanService()
+
+request = DeliveryChallanRequest(
+    challan_type="job_work",
+    challan_date=date.today(),
+    hsn_code="7208",
+    items=[
+        DeliveryChallanItem(
+            coil_number="TEST001",
+            description="CRNO COIL",
+            grade="CRNO",
+            width=1000,
+            thk=0.5,
+            coating="None",
+            weight_kg=1000,
+            weight_mt=1.0,
+            nature_of_processing="Slitting",
+            hsn_code="7208",
+            rate_per_mt=50000,
+            value=50000,
+        )
+    ],
+)
+
+challan = service.create_delivery_challan(request)
+
+print("Created Challan:", challan)

--- a/test_pdf.py
+++ b/test_pdf.py
@@ -1,0 +1,8 @@
+from src.data_entry.service.delivery_challan_service import DeliveryChallanService
+service = DeliveryChallanService()
+challan_number = "F/001/25-26"   # change if needed
+pdf_bytes = service.generate_challan_pdf(challan_number)
+with open("delivery_challan.pdf", "wb") as f:
+    f.write(pdf_bytes)
+
+print("PDF Generated Successfully")


### PR DESCRIPTION
## Summary
- Adds Delivery Challan page with four generation modes: Manual, From Coil Number, From Party, Unused Coils (Year-End)
- Adds Consignee Master integration and challan number generation (`F/NNN/YY-YY`)
- Adds PDF generation for delivery challans via `fpdf2`
- Adds `num2words` dependency for amount-in-words
- Includes changes to weight_receipt, rm_inward, and sales_order flows (to be reviewed for scope)

## Test plan
- [ ] Verify PDF renders correctly with multiple coils (check for-loop bug in `generate_challan_pdf`)
- [ ] Verify PDF layout matches required GST job-work challan format
- [ ] Verify double-click prevention on Generate button
- [ ] Verify Consignee Master dropdown loads and auto-fills address fields
- [ ] Review out-of-scope changes to weight_receipt.py, rm_inward_service.py, sales_order.py
- [ ] Remove stray test files at repo root (`test_pdf.py`, `test_delivery_challan.py`)