### PR TITLE
feat(weight-receipt): add crane scale selector

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ class APISettings(BaseModel):
     google_service_account_json: Optional[str] = Field(default=None)
     google_sheets_id: Optional[str] = Field(default=None)
     weighing_scale_url: Optional[str] = Field(default=None)
+    weighing_scale_crane_url: Optional[str] = Field(default=None)
 
 class PowerAutomateSettings(BaseModel):
     pa_client_id: Optional[str] = Field(default=None)

--- a/pages/weight_receipt.py
+++ b/pages/weight_receipt.py
@@ -45,6 +45,8 @@ def initialize_wr_session_state():
         st.session_state.wr_is_manual_entry = False
     if 'wr_pending_save' not in st.session_state:
         st.session_state.wr_pending_save = None
+    if 'wr_scale_type' not in st.session_state:
+        st.session_state.wr_scale_type = "Standard"
 
 def _is_manual_entry_authorized():
     """Check if the current user is authorized for manual weight entry."""
@@ -347,6 +349,7 @@ def render_weight_receipt_form():
                 st.session_state.wr_design_deductions = {}
                 st.session_state.wr_selected_designs = set()
                 st.session_state.wr_is_manual_entry = False
+                st.session_state.wr_scale_type = "Standard"
 
                 # Crucial: Clear specific widget keys from session state to prevent StreamlitValueAboveMaxError
                 # and stale values in inputs. We clear up to a reasonable number of designs.
@@ -395,11 +398,19 @@ def render_weight_receipt_form():
             default_mode_index = 0 if order_type == "CORE_BUILDING" else 1
             
             selected_mode = st.radio(
-                "Weighing Mode", 
-                mode_options, 
-                index=default_mode_index, 
+                "Weighing Mode",
+                mode_options,
+                index=default_mode_index,
                 horizontal=True,
                 help="Choose 'Total Weight' to weigh the entire set at once, or 'Individual Items' to weigh specific designs."
+            )
+
+            st.radio(
+                "Weighing Scale",
+                ["Standard", "Crane"],
+                horizontal=True,
+                key="wr_scale_type",
+                help="Standard scale for regular weights; Crane scale for heavy cores."
             )
 
             is_itemized_mode = (selected_mode == "Individual Items")
@@ -581,7 +592,8 @@ def render_weight_receipt_form():
                     selected_indices = st.session_state.get('wr_selected_designs', set())
                     if len(selected_indices) > 0:
                         with st.spinner("Fetching weight..."):
-                            response_data = services.weight_receipt.get_current_weight_from_scale()
+                            scale_type = st.session_state.get("wr_scale_type", "Standard").lower()
+                            response_data = services.weight_receipt.get_current_weight_from_scale(scale_type=scale_type)
                             if response_data.get("success") and response_data.get("status") == "stable":
                                 total_scale_weight = response_data.get("weight", 0.0)
                                 st.session_state.wr_is_manual_entry = False
@@ -914,7 +926,8 @@ def render_weight_receipt_form():
 
                 if get_weight_clicked_core or add_weight_clicked_core:
                     with st.spinner("Fetching weight..."):
-                        response_data = services.weight_receipt.get_current_weight_from_scale()
+                        scale_type = st.session_state.get("wr_scale_type", "Standard").lower()
+                        response_data = services.weight_receipt.get_current_weight_from_scale(scale_type=scale_type)
                         if response_data.get("success") and response_data.get("status") == "stable":
                             weight = response_data.get("weight", 0.0)
                             st.session_state.wr_is_manual_entry = False

--- a/src/data_entry/service/weight_receipt_service.py
+++ b/src/data_entry/service/weight_receipt_service.py
@@ -20,7 +20,10 @@ class WeightReceiptService:
 
     def __init__(self):
         self.repository = WeightReceiptRepository()
-        self.weighing_scale_api_url = settings.api.weighing_scale_url
+        self._scale_urls = {
+            "standard": settings.api.weighing_scale_url,
+            "crane": settings.api.weighing_scale_crane_url,
+        }
         self.google_service = google_drive_service
         self.spreadsheet_id = settings.api.google_sheets_id
 
@@ -151,13 +154,15 @@ class WeightReceiptService:
             logger.error(f"Error fetching weight receipts for party {party_name}: {str(e)}")
             return []
 
-    def get_current_weight_from_scale(self) -> dict:
+    def get_current_weight_from_scale(self, scale_type: str = "standard") -> dict:
         """
         Fetches the current weight from the external weighing scale API.
+        `scale_type` selects which physical scale to read from ("standard" or "crane").
         Returns a dict with 'success', 'weight', and 'status'.
         """
-        if not self.weighing_scale_api_url:
-            logger.error("Weighing scale API URL is not configured.")
+        url = self._scale_urls.get(scale_type)
+        if not url:
+            logger.error(f"Weighing scale URL for '{scale_type}' is not configured.")
             return {"success": False, "weight": 0.0, "status": "unconfigured"}
 
         headers = {
@@ -165,7 +170,7 @@ class WeightReceiptService:
         }
 
         try:
-            response = requests.get(self.weighing_scale_api_url, headers=headers, timeout=10)
+            response = requests.get(url, headers=headers, timeout=10)
             response.raise_for_status() # Raise an HTTPError for bad responses (4xx or 5xx)
             data = response.json()
             return {


### PR DESCRIPTION
## Summary
- Adds a per-job-card **Weighing Scale** toggle (Standard / Crane) on the Weight Receipt page so operators can route **Get Weight** / **Add Weight** clicks to the new crane scale.
- Service layer now holds both URLs and picks one via a `scale_type` argument; response contract is unchanged, so downstream math (deductions, FG posting, drafts) needs no changes.
- Selector resets to **Standard** whenever the job card changes so a stale crane selection cannot leak into the next receipt.

## Files changed
- `config.py` — new `weighing_scale_crane_url` field in `APISettings`.
- `src/data_entry/service/weight_receipt_service.py` — `_scale_urls` dict + new `scale_type="standard"` arg on `get_current_weight_from_scale`.
- `pages/weight_receipt.py` — new radio under the Weighing Mode radio (keyed `wr_scale_type`), session init, JC-change reset, and threading through the two existing scale-fetch call sites (Loose Strips + Building Core). Manual-entry paths are untouched because they bypass the scale.

## Deploy note
Add `weighing_scale_crane_url` under `[api]` in Streamlit Cloud secrets (already set locally):
`weighing_scale_crane_url = "https://pseudoviscous-cordiform-kenneth.ngrok-free.dev/get-crane-weight"`

## Test plan
- [x] Open the Weight Receipt page, pick a party and a job card.
- [x] Confirm the new **Weighing Scale** radio appears under **Weighing Mode** and defaults to **Standard**.
- [x] With **Standard** selected, click **Get Weight** / **Add Weight** on both a Loose Strips JC and a Building Core JC — verify weight comes from `/get-weight` as before.
- [ ] Flip to **Crane** and repeat — verify weight now comes from `/get-crane-weight`.
- [x] Switch to a different job card — confirm the radio snaps back to **Standard**.
- [x] Confirm manual weight entry (for authorized users) still works unchanged, independent of the scale selection.
- [ ] Save a Weight Receipt end-to-end with each scale and verify FG posting / draft behavior is unaffected.