### PR TITLE
feat(weight-receipt): source PO Date and Type from JC, suppress sets …

### DIFF
--- a/pages/weight_receipt.py
+++ b/pages/weight_receipt.py
@@ -64,6 +64,11 @@ def _should_post_to_finished_goods() -> bool:
     return material not in FG_EXCLUDED_MATERIALS
 
 
+def _is_rn_series_jc(job_card_number: str) -> bool:
+    """RN- prefix marks E&I orders, which have no concept of sets."""
+    return str(job_card_number or "").strip().upper().startswith("RN-")
+
+
 @st.dialog("Confirm Weight Receipt Save", width="large")
 def _show_save_confirmation_dialog(candidate_designs, job_card_number, party_name):
     """
@@ -791,6 +796,7 @@ def render_weight_receipt_form():
                     weighed_designs = []
                     actual_total_weight = 0.0
                     sum_design_deductions = 0.0
+                    is_rn_series = _is_rn_series_jc(selected_jc_str)
 
                     for i, row in edited_df.iterrows():
                         actual_weight = row["Actual Wt."]
@@ -802,7 +808,7 @@ def render_weight_receipt_form():
                             weighed_design_data['actual_weight'] = actual_weight
                             weighed_design_data['remark'] = row["Remark"]
                             weighed_design_data['design_deduction'] = row["Design Deduction"]
-                            weighed_design_data['sets'] = row["Sets"]
+                            weighed_design_data['sets'] = None if is_rn_series else row["Sets"]
                             weighed_designs.append(WeighedDesignDetail(**weighed_design_data))
 
                     if not weighed_designs:
@@ -837,8 +843,8 @@ def render_weight_receipt_form():
                         job_card_number=selected_jc_str,
                         party_name=selected_party,
                         po_no=selected_jc.get('po_no', 'N/A'),
-                        material=selected_jc.get('material', 'N/A'),
-                        sets=st.session_state.get('wr_sets_for_receipt', 0),
+                        material=(st.session_state.get('wr_material_type') or '').strip() or 'N/A',
+                        sets=0 if is_rn_series else st.session_state.get('wr_sets_for_receipt', 0),
                         designs=weighed_designs,
                         weight_entry_type="Loose Strips (Manual)" if st.session_state.get('wr_is_manual_entry') else "Loose Strips",
                         total_weight=actual_total_weight,
@@ -1006,11 +1012,14 @@ def render_weight_receipt_form():
                         st.error("Please fetch a valid total weight before saving.")
                         st.stop()
 
+                    is_rn_series = _is_rn_series_jc(selected_jc_str)
                     weighed_designs = []
                     for design_item in designs:
                         weighed_design_data = design_item.copy()
-                        weighed_design_data['actual_weight'] = 0 
+                        weighed_design_data['actual_weight'] = 0
                         weighed_design_data['remark'] = st.session_state.get('wr_core_remark', '')
+                        if is_rn_series:
+                            weighed_design_data['sets'] = None
                         weighed_designs.append(WeighedDesignDetail(**weighed_design_data))
 
                     # Validate cumulative weight for partial dispatch orders
@@ -1036,8 +1045,8 @@ def render_weight_receipt_form():
                         job_card_number=selected_jc_str,
                         party_name=selected_party,
                         po_no=selected_jc.get('po_no', 'N/A'),
-                        material=selected_jc.get('material', 'N/A'),
-                        sets=st.session_state.get('wr_sets_for_receipt', 0),
+                        material=(st.session_state.get('wr_material_type') or '').strip() or 'N/A',
+                        sets=0 if is_rn_series else st.session_state.get('wr_sets_for_receipt', 0),
                         designs=weighed_designs,
                         weight_entry_type="Building Core (Manual)" if st.session_state.get('wr_is_manual_entry') else "Building Core",
                         total_weight=actual_total_weight,

--- a/src/data_entry/service/weight_receipt_service.py
+++ b/src/data_entry/service/weight_receipt_service.py
@@ -284,6 +284,31 @@ class WeightReceiptService:
             logger.error(f"Error in get_material_type_for_job_card for JC {job_card_number}: {e}")
             return ""
 
+    def get_job_card_material_type_map(self) -> dict:
+        """
+        Returns a {job_card_number_lower: material_type} dict built from the flat
+        'Sales Order' sheet. Used by the PDF generator to backfill the Type field
+        for older receipts (where the Material column may be empty or 'N/A').
+        """
+        try:
+            df = self.google_service.get_worksheet_data(self.spreadsheet_id, "Sales Order", header_row=1)
+            if df is None or df.empty:
+                return {}
+
+            jc_col = next((c for c in ("Job Card", "job_card_number", "Job Card No", "job_card", "JobCard") if c in df.columns), None)
+            type_col = next((c for c in ("type", "Type", "material_type", "Material Type", "Material") if c in df.columns), None)
+            if not jc_col or not type_col:
+                return {}
+
+            df = df[[jc_col, type_col]].dropna(subset=[jc_col]).copy()
+            df[jc_col] = df[jc_col].astype(str).str.strip().str.lower()
+            # Deduplicate; first occurrence wins
+            df = df.drop_duplicates(subset=[jc_col], keep='first')
+            return {row[jc_col]: ("" if pd.isna(row[type_col]) else str(row[type_col]).strip()) for _, row in df.iterrows()}
+        except Exception as e:
+            logger.error(f"Error building job card → material type map: {e}")
+            return {}
+
     def get_order_type_for_job_card(self, job_card_number: str) -> str:
         """
         Retrieves the order type for a given job card from the Sales Order-JC sheet.

--- a/src/pdf_generator/service/pdf_service.py
+++ b/src/pdf_generator/service/pdf_service.py
@@ -649,11 +649,19 @@ class PDFService:
 
         return bytes(pdf.output(dest='S'))
 
-    def _draw_weight_receipt(self, pdf: FPDF, receipt_data: dict, rate: str = 'N/A'):
-        """Draws a single Weight Receipt on the current PDF page."""
+    def _draw_weight_receipt(self, pdf: FPDF, receipt_data: dict, rate: str = 'N/A', po_date=None, material_type: str = None):
+        """Draws a single Weight Receipt on the current PDF page.
+
+        Args:
+            po_date: PO/order date sourced from the Sales Order-JC sheet. Falls back
+                to the receipt date if not supplied (e.g., legacy receipts whose JC
+                row no longer exists).
+            material_type: Material type sourced from the flat Sales Order sheet.
+                Falls back to receipt_data['Material'] when missing.
+        """
         pdf.add_page()
         pdf.set_auto_page_break(auto=True, margin=15) # Re-enable auto page break for multi-page documents
-        
+
         # Title
         pdf.set_font("Helvetica", 'B', 18)
         pdf.cell(0, 10, f"Weight Receipt No: {receipt_data.get('WeightReceiptNumber', 'N/A')}", ln=True, align='C')
@@ -661,13 +669,17 @@ class PDFService:
 
         # --- Header Box ---
         line_height = 8
-        
+
         # Get data
         party_name = receipt_data.get('PartyName', 'N/A')
         po_no = receipt_data.get('PONumber', 'N/A')
         receipt_date_obj = receipt_data.get('Date')
         receipt_date = pd.to_datetime(receipt_date_obj, dayfirst=True).strftime('%d/%m/%Y') if pd.notna(receipt_date_obj) else 'N/A'
+        # PO Date comes from the JC's order_date; fall back to the receipt date for legacy/missing JCs.
+        po_date_display = pd.to_datetime(po_date, dayfirst=True).strftime('%d/%m/%Y') if pd.notna(po_date) else receipt_date
         card_no = receipt_data.get('JobCardNumber', 'N/A')
+        # RN- prefix marks E&I orders, which have no concept of sets — suppress them in the PDF.
+        is_rn_series = str(card_no).strip().upper().startswith('RN-')
         
         designs = json.loads(receipt_data.get('DesignDetailsWithWeightsJSON', '[]'))
         job_no = designs[0].get('party_job_no', 'N/A') if designs else 'N/A'
@@ -687,7 +699,7 @@ class PDFService:
         pdf.set_font("Helvetica", 'B', 12)
         pdf.cell(25, line_height, "PO Date", border='B')
         pdf.set_font("Helvetica", '', 12)
-        pdf.cell(0, line_height, f": {receipt_date}", border='B,R', ln=True)
+        pdf.cell(0, line_height, f": {po_date_display}", border='B,R', ln=True)
 
         # Line 3: Card No and Job No
         pdf.set_font("Helvetica", 'B', 12)
@@ -794,8 +806,8 @@ class PDFService:
                 if item.get('mm_stack'):
                     description += f" X {item.get('mm_stack', '')}"
                 
-                # Show sets if present (Itemized Mode)
-                if item.get('sets'):
+                # Show sets if present (Itemized Mode); suppress for RN- (E&I) job cards.
+                if item.get('sets') and not is_rn_series:
                     description += f" ({item.get('sets')} sets)"
                 
                 item_remark = item.get('remark', '')
@@ -822,28 +834,40 @@ class PDFService:
                 pdf.cell(net_w, row_height, f"{net_weight:.3f}" if weight > 0 else "", border=1, align='R', ln=True)
 
         # --- Table Footer ---
+        # Type / Set / Rem each get their own line, stacked inside the Description
+        # column. Avoids overflow when any one value (e.g. 'CRNO EI TRD' type or a
+        # long remark) is wider than its previous narrow sub-cell.
         pdf.set_font("Helvetica", '', 10)
-        # Empty Sr No cell
-        pdf.cell(sr_no_w, 8, '', border='LTB')
 
-        # Type (40mm) + Set (20mm) + Remark (rest)
-        # Width sum must match desc_w = 80
-        # Let's adjust widths to fit nicely
-        
-        type_w = 30
-        set_w = 15
-        rem_w = 35 
-        
-        pdf.cell(type_w, 8, f"Type: {receipt_data.get('Material', 'N/A')}", border='TB')
-        pdf.cell(set_w, 8, f"Set: {receipt_data.get('Sets', 'N/A')}", border='TB')
-        
+        row_h = 5
+        footer_h = row_h * 3
+
+        type_value = (material_type if material_type else None) or receipt_data.get('Material') or 'N/A'
+        type_text = f"Type: {type_value}"
+        set_text = "" if is_rn_series else f"Set: {receipt_data.get('Sets', 'N/A')}"
         remark_text = f"Rem: {core_receipt_remark}" if is_core_building and core_receipt_remark else ""
-        pdf.cell(rem_w, 8, remark_text, border='TB')
+
+        y0 = pdf.get_y()
+        x0 = pdf.get_x()
+
+        # Sr No (empty, spans full footer height)
+        pdf.cell(sr_no_w, footer_h, '', border='LTB')
+        x_desc = x0 + sr_no_w
+
+        # Three stacked lines in the Description column. Borders only on outer
+        # edges (T on first row, B on last) so the footer reads as a single box.
+        pdf.set_xy(x_desc, y0)
+        pdf.cell(desc_w, row_h, type_text, border='T', align='L')
+        pdf.set_xy(x_desc, y0 + row_h)
+        pdf.cell(desc_w, row_h, set_text, border=0, align='L')
+        pdf.set_xy(x_desc, y0 + 2 * row_h)
+        pdf.cell(desc_w, row_h, remark_text, border='B', align='L')
+
+        pdf.set_xy(x_desc + desc_w, y0)
 
         # Totals
-        # Weights should align with columns
         pdf.set_font("Helvetica", 'B', 10)
-        
+
         # Recalculate based on the logic above
         if not is_core_building and sum_design_deductions > 0:
              final_deduction = sum_design_deductions
@@ -852,9 +876,9 @@ class PDFService:
 
         net_weight = total_weight - final_deduction
 
-        pdf.cell(gross_w, 8, f"{total_weight:.3f}", border=1, align='R')
-        pdf.cell(deduction_w, 8, f"{final_deduction:.3f}", border=1, align='R')
-        pdf.cell(net_w, 8, f"{net_weight:.3f}", border=1, align='R', ln=True)
+        pdf.cell(gross_w, footer_h, f"{total_weight:.3f}", border=1, align='R')
+        pdf.cell(deduction_w, footer_h, f"{final_deduction:.3f}", border=1, align='R')
+        pdf.cell(net_w, footer_h, f"{net_weight:.3f}", border=1, align='R', ln=True)
         pdf.ln(2)
 
         # --- Details below table ---
@@ -887,7 +911,13 @@ class PDFService:
         pdf = FPDF(orientation='P', unit='mm', format='A4')
         sales_orders = self.sales_order_service.get_sales_orders_for_job_card(include_designs=False)
         sales_order_rates = {so.get('job_card_number'): so.get('rate_per_kg', 'N/A') for so in sales_orders if so.get('job_card_number')}
+        sales_order_po_dates = {so.get('job_card_number'): so.get('order_date') for so in sales_orders if so.get('job_card_number')}
+        # Built once per PDF generation; used as a fallback for legacy receipts whose Material column is missing/N/A.
+        material_type_map = self.weight_receipt_service.get_job_card_material_type_map()
         for receipt_data in selected_receipts:
-            rate = sales_order_rates.get(receipt_data.get('JobCardNumber'), 'N/A')
-            self._draw_weight_receipt(pdf, receipt_data, rate)
+            jc = receipt_data.get('JobCardNumber')
+            rate = sales_order_rates.get(jc, 'N/A')
+            po_date = sales_order_po_dates.get(jc)
+            material_type = material_type_map.get(str(jc).strip().lower(), '') if jc else ''
+            self._draw_weight_receipt(pdf, receipt_data, rate, po_date=po_date, material_type=material_type)
         return bytes(pdf.output(dest='S'))


### PR DESCRIPTION
…for RN-series, stack PDF footer

- PO Date in PDF now reads the JC's order_date (falls back to receipt date for legacy receipts).
- Type now uses wr_material_type when saving; PDF backfills from the flat Sales Order sheet for older receipts where Material was 'N/A'.
- RN- job cards (E&I, no concept of sets): receipt saves sets=0 and per-design sets=None; PDF skips the per-design '(N sets)' annotation and the footer Set: cell.
- Footer Type/Set/Rem now render on three stacked lines inside the description column so long values (e.g. 'CRNO EI TRD' type, multi-word remarks) no longer overflow into the totals columns.