### PR TITLE
fix(weight-receipt): fail closed on Sheets read error; preview number…

### DIFF
--- a/pages/weight_receipt.py
+++ b/pages/weight_receipt.py
@@ -70,13 +70,23 @@ def _is_rn_series_jc(job_card_number: str) -> bool:
 
 
 @st.dialog("Confirm Weight Receipt Save", width="large")
-def _show_save_confirmation_dialog(candidate_designs, job_card_number, party_name):
+def _show_save_confirmation_dialog(candidate_designs, job_card_number, party_name, preview_wr_number=None):
     """
     Shows a modal dialog with all weighed designs for the user to review
     and optionally deselect before saving. This is the final selection
     step — the grid checkboxes are only used for weighing.
+
+    `preview_wr_number` is a best-effort, NON-binding preview of the next
+    receipt number. The binding number is still allocated at save time (to
+    avoid race conditions), so this is shown as approximate and may differ
+    by one if another receipt is saved while this dialog is open.
     """
     st.markdown(f"**Job Card:** {job_card_number} &nbsp; | &nbsp; **Party:** {party_name}")
+    if preview_wr_number is not None:
+        st.markdown(f"**Weight Receipt No. (approx.):** ~{preview_wr_number}")
+        st.caption("Approximate — the final number is assigned when you click Confirm Save.")
+    else:
+        st.caption("Weight Receipt number will be assigned when you click Confirm Save.")
     st.markdown("Review the designs below. **Uncheck** any you don't want to save.")
     st.markdown("---")
 
@@ -772,10 +782,22 @@ def render_weight_receipt_form():
                     if not candidate_designs:
                         st.error("Please weigh at least one item before saving.", icon="⚠️")
                     else:
+                        # Best-effort preview of the next receipt number, computed
+                        # ONCE here (not inside the dialog, which reruns on every
+                        # interaction). Non-binding: the real number is allocated
+                        # at Confirm Save. A failed read must not block the
+                        # dialog — fall back to None and the dialog hides it.
+                        try:
+                            preview_wr_number = services.weight_receipt.get_next_weight_receipt_number()
+                        except Exception as e:
+                            logger.debug("WR number preview unavailable for JC %s: %s", selected_jc_str, e)
+                            preview_wr_number = None
+
                         _show_save_confirmation_dialog(
                             candidate_designs,
                             job_card_number=selected_jc_str,
-                            party_name=selected_party
+                            party_name=selected_party,
+                            preview_wr_number=preview_wr_number,
                         )
 
                 # --- Step 2: Process confirmed save (triggered by dialog rerun) ---
@@ -835,7 +857,19 @@ def render_weight_receipt_form():
                                 icon="⚠️"
                             )
 
-                    generated_wr_number = services.weight_receipt.generate_weight_receipt_number()
+                    try:
+                        generated_wr_number = services.weight_receipt.generate_weight_receipt_number()
+                    except Exception as e:
+                        logger.error("WR number allocation failed for JC %s: %s", selected_jc_str, e)
+                        if selected_jc_str in st.session_state.wr_save_locks:
+                            del st.session_state.wr_save_locks[selected_jc_str]
+                        st.error(
+                            "Couldn't reach Google Sheets to allocate a receipt number "
+                            "(likely a temporary rate limit). Nothing was saved — "
+                            "please wait a minute and click Save again.",
+                            icon="⚠️"
+                        )
+                        st.stop()
 
                     request = WeightReceiptRequest(
                         weight_receipt_number=generated_wr_number,
@@ -1037,7 +1071,19 @@ def render_weight_receipt_form():
                             )
 
                     # Generate weight receipt number at save time to prevent race conditions
-                    generated_wr_number = services.weight_receipt.generate_weight_receipt_number()
+                    try:
+                        generated_wr_number = services.weight_receipt.generate_weight_receipt_number()
+                    except Exception as e:
+                        logger.error("WR number allocation failed for JC %s: %s", selected_jc_str, e)
+                        if selected_jc_str in st.session_state.wr_save_locks:
+                            del st.session_state.wr_save_locks[selected_jc_str]
+                        st.error(
+                            "Couldn't reach Google Sheets to allocate a receipt number "
+                            "(likely a temporary rate limit). Nothing was saved — "
+                            "please wait a minute and click Save again.",
+                            icon="⚠️"
+                        )
+                        st.stop()
 
                     request = WeightReceiptRequest(
                         weight_receipt_number=generated_wr_number,

--- a/src/data_entry/repository/weight_receipt_repository.py
+++ b/src/data_entry/repository/weight_receipt_repository.py
@@ -11,9 +11,16 @@ class WeightReceiptRepository:
         self.spreadsheet_id = settings.api.google_sheets_id
         self.worksheet_name = "WeightReceipts"
 
-    def get_all_weight_receipts(self) -> pd.DataFrame:
-        """Fetches all weight receipts from the Google Sheet."""
-        return self.google_service.get_worksheet_data(self.spreadsheet_id, self.worksheet_name, header_row=1)
+    def get_all_weight_receipts(self, raise_on_error: bool = False) -> pd.DataFrame:
+        """Fetches all weight receipts from the Google Sheet.
+
+        raise_on_error=True propagates read failures instead of returning an
+        empty DataFrame — required for receipt-number allocation.
+        """
+        return self.google_service.get_worksheet_data(
+            self.spreadsheet_id, self.worksheet_name, header_row=1,
+            raise_on_error=raise_on_error,
+        )
 
     def save_weight_receipt(self, data_row: list) -> bool:
         """Saves a new weight receipt to the Google Sheet."""

--- a/src/data_entry/service/weight_receipt_service.py
+++ b/src/data_entry/service/weight_receipt_service.py
@@ -27,10 +27,15 @@ class WeightReceiptService:
         self.google_service = google_drive_service
         self.spreadsheet_id = settings.api.google_sheets_id
 
-    def _get_or_refresh_all_weight_receipts(self, force_refresh: bool = False) -> pd.DataFrame:
+    def _get_or_refresh_all_weight_receipts(
+        self, force_refresh: bool = False, raise_on_error: bool = False
+    ) -> pd.DataFrame:
         """
         Retrieves all weight receipts from the repository, using an internal cache.
         If the cache is stale or force_refresh is True, it fetches new data.
+
+        raise_on_error=True propagates a read failure (the repository raises
+        before the cache is touched, so a failed read never poisons the cache).
         """
         current_time = datetime.now()
         if (
@@ -41,9 +46,9 @@ class WeightReceiptService:
         ):
             logger.debug("Using cached all weight receipts DataFrame.")
             return self._cached_all_weight_receipts_df
-        
+
         logger.debug("Refreshing all weight receipts DataFrame (cache stale or forced).")
-        df = self.repository.get_all_weight_receipts()
+        df = self.repository.get_all_weight_receipts(raise_on_error=raise_on_error)
         self._cached_all_weight_receipts_df = df
         self._cached_all_weight_receipts_timestamp = current_time
         return df
@@ -51,31 +56,46 @@ class WeightReceiptService:
     def get_next_weight_receipt_number(self) -> int:
         """
         Generates the next sequential weight receipt number.
-        Starts from 10315 if no higher numeric-only number is found.
+
+        Returns the seed 10315 ONLY when the WeightReceipts sheet was read
+        successfully and is genuinely empty. If the sheet cannot be read
+        (Google Sheets rate limit / network error), this RAISES so the caller
+        aborts the save — it must NOT fall back to a seed or timestamp number,
+        because that silently writes a duplicate/regressed receipt number.
+
+        Incident 2026-05-16: a 429 read-quota error returned an empty
+        DataFrame, the old code treated it as "empty sheet", and WR was saved
+        as the seed 10315 instead of 10957.
         """
         try:
-            # Use the internally cached DataFrame
-            df = self._get_or_refresh_all_weight_receipts()
-            
+            # Strict read: a failed read must propagate, not look like "empty".
+            df = self._get_or_refresh_all_weight_receipts(raise_on_error=True)
+
             if df is None or df.empty or "WeightReceiptNumber" not in df.columns:
+                # Genuine empty/new sheet (the read succeeded with zero rows).
                 return 10315
 
             max_receipt_num = 10314  # The base number to compare against
-            
+
             # Filter for strings that are purely numeric, then convert and find max
             numeric_receipts = pd.to_numeric(df['WeightReceiptNumber'], errors='coerce').dropna()
-            
+
             if not numeric_receipts.empty:
                 current_max = numeric_receipts.max()
                 if current_max > max_receipt_num:
                     max_receipt_num = int(current_max)
-            
+
             return max_receipt_num + 1
 
         except Exception as e:
-            logger.error(f"Error generating next weight receipt number: {e}")
-            # Fallback to a timestamp-based unique number in case of error
-            return int(datetime.now().timestamp())
+            # Log for observability, then re-raise. NO seed/timestamp fallback:
+            # the caller is responsible for aborting the save and asking the
+            # user to retry once Sheets is reachable again.
+            logger.error(
+                "Could not read WeightReceipts to allocate a receipt number; "
+                "aborting instead of falling back to a seed/timestamp: %s", e
+            )
+            raise
 
     def generate_weight_receipt_number(self) -> str:
         """Generates a new sequential weight receipt number as a string."""

--- a/src/shared/integrations/google_drive_service.py
+++ b/src/shared/integrations/google_drive_service.py
@@ -129,9 +129,18 @@ class GoogleDriveService:
             self.client = None
 
     def get_worksheet_data(
-        self, spreadsheet_id: str, worksheet_name: str, header_row: int = 1
+        self, spreadsheet_id: str, worksheet_name: str, header_row: int = 1,
+        raise_on_error: bool = False,
     ) -> pd.DataFrame:
-        """Get data from a specific worksheet, specifying the header row."""
+        """Get data from a specific worksheet, specifying the header row.
+
+        By default a read failure (rate limit, network, etc.) is swallowed and
+        an empty DataFrame is returned (legacy behavior). Pass
+        raise_on_error=True for callers where "empty sheet" and "failed to
+        read" must NOT be conflated — e.g. sequential ID allocation, where
+        treating a failed read as an empty sheet writes a duplicate/seed
+        number. With raise_on_error=True the exception propagates.
+        """
         try:
             if not self.client:
                 raise Exception("Google Drive client not initialized")
@@ -153,9 +162,13 @@ class GoogleDriveService:
 
         except APIError as e:
             logger.error(f"A gspread API error occurred while reading '{worksheet_name}': {str(e)}")
+            if raise_on_error:
+                raise
             return pd.DataFrame()
         except Exception as e:
             logger.error(f"An unexpected error occurred while reading worksheet '{worksheet_name}': {str(e)}")
+            if raise_on_error:
+                raise
             return pd.DataFrame()
 
     def get_dropdown_options(

--- a/tests/data_entry/service/test_weight_receipt_service.py
+++ b/tests/data_entry/service/test_weight_receipt_service.py
@@ -201,3 +201,51 @@ def test_clear_drafts_for_design_indices_no_matching_indices(wr_service_with_goo
     written_data = mock_worksheet.update.call_args[0][0]
     # headers + 1 original row (unchanged)
     assert len(written_data) == 2
+
+
+# --- Tests for get_next_weight_receipt_number ---
+# Regression guard for incident 2026-05-16: a Google Sheets 429 read-quota
+# error returned an empty DataFrame, the old code read that as "empty sheet",
+# and a Weight Receipt was saved as the seed 10315 instead of 10957.
+
+def test_next_number_is_max_plus_one(weight_receipt_service):
+    """Normal case: next number is (max existing numeric number) + 1."""
+    df = pd.DataFrame({'WeightReceiptNumber': ['10955', '10956']})
+    weight_receipt_service.repository.get_all_weight_receipts.return_value = df
+
+    assert weight_receipt_service.get_next_weight_receipt_number() == 10957
+
+
+def test_next_number_seed_on_genuinely_empty_sheet(weight_receipt_service):
+    """A *successful* read that returns zero rows -> the 10315 seed is valid."""
+    weight_receipt_service.repository.get_all_weight_receipts.return_value = pd.DataFrame()
+
+    assert weight_receipt_service.get_next_weight_receipt_number() == 10315
+
+
+def test_next_number_raises_on_read_failure_no_seed_fallback(weight_receipt_service):
+    """
+    The core fix: when the receipts sheet cannot be read, numbering must
+    RAISE — it must NOT silently fall back to the seed 10315 (or a
+    timestamp), because that writes a duplicate/regressed receipt number.
+    """
+    weight_receipt_service.repository.get_all_weight_receipts.side_effect = (
+        Exception("APIError [429]: Quota exceeded for 'Read requests'")
+    )
+
+    with pytest.raises(Exception):
+        weight_receipt_service.get_next_weight_receipt_number()
+
+
+def test_next_number_uses_strict_read(weight_receipt_service):
+    """
+    Numbering must request a strict read (raise_on_error=True) so a failed
+    read can never masquerade as an empty sheet.
+    """
+    df = pd.DataFrame({'WeightReceiptNumber': ['10956']})
+    weight_receipt_service.repository.get_all_weight_receipts.return_value = df
+
+    weight_receipt_service.get_next_weight_receipt_number()
+
+    _, kwargs = weight_receipt_service.repository.get_all_weight_receipts.call_args
+    assert kwargs.get('raise_on_error') is True


### PR DESCRIPTION
… in dialog

Incident 2026-05-16: a Google Sheets 429 read-quota error returned an empty DataFrame, get_next_weight_receipt_number() read that as "empty sheet", and a receipt was saved as the seed 10315 instead of 10957.

- google_drive_service.get_worksheet_data: add raise_on_error so callers can distinguish "empty sheet" from "read failed" (default keeps legacy swallow-and-return-empty behavior).
- repository / service: thread raise_on_error through; numbering now does a strict read and RAISES on failure instead of falling back to the seed or a timestamp. Cache is only written after a successful read.
- weight_receipt.py: both save paths abort cleanly on allocation failure (release save lock, show retry message, st.stop) so nothing is written.
- Confirmation dialog shows a best-effort, non-binding preview of the next number computed once before the dialog opens; the binding number is still allocated at Confirm Save (no added race risk).
- Add 4 regression tests for get_next_weight_receipt_number.