### PR TITLE
fix: round mm_stack to 2 decimal places to prevent PDF overflow

### DIFF
--- a/pages/pdf_generator.py
+++ b/pages/pdf_generator.py
@@ -179,7 +179,7 @@ def render_delivery_challan_tab(services: AppServices):
                                     for idx, design in enumerate(designs):
                                         description = f"{design.get('width', '')} X {design.get('length', '')}"
                                         if design.get('mm_stack'):
-                                            description += f" X {design.get('mm_stack', '')}"
+                                            description += f" X {float(design.get('mm_stack')):.2f}"
                                         
                                         # Only show weight/deduction/net on the LAST item for Building Core group
                                         is_last = (idx == num_designs - 1)
@@ -217,7 +217,7 @@ def render_delivery_challan_tab(services: AppServices):
                                         remark = design.get('remark', '')
                                         description = f"{design.get('width', '')} X {design.get('length', '')}"
                                         if design.get('mm_stack'):
-                                            description += f" X {design.get('mm_stack', '')}"
+                                            description += f" X {float(design.get('mm_stack')):.2f}"
                                             
                                         temp_items.append({
                                             "description": description,

--- a/pages/sales_order.py
+++ b/pages/sales_order.py
@@ -293,7 +293,7 @@ def add_design_to_state():
             if width_m * length_m * density_kg_m3 == 0: raise ValueError("Width, Length, and Density must be non-zero.")
             
             stack_per_set_m = (weight_per_set / (width_m * length_m * density_kg_m3))
-            mm_stack = (stack_per_set_m * 1000) * num_sets
+            mm_stack = round((stack_per_set_m * 1000) * num_sets, 2)
         else:
             stack_per_set_mm = st.session_state.design_mm_stack
             mm_stack = stack_per_set_mm * num_sets

--- a/src/pdf_generator/service/pdf_service.py
+++ b/src/pdf_generator/service/pdf_service.py
@@ -380,7 +380,7 @@ class PDFService:
             pdf.rect(hole_cell_x, hole_cell_y, hole_cell_width, row_height)
             pdf.set_x(hole_cell_x + hole_cell_width)
 
-            pdf.cell(30, row_height, "" if item.get('mm_stack') is None else str(item.get('mm_stack')), border=1, align='C')
+            pdf.cell(30, row_height, "" if item.get('mm_stack') is None else f"{float(item.get('mm_stack')):.2f}", border=1, align='C')
             pdf.cell(30, row_height, "" if item.get('pcs') == 0 else str(item.get('pcs')), border=1, align='C')
             
             weight = 0
@@ -765,7 +765,7 @@ class PDFService:
                 desc_x = pdf.get_x()
                 description = f"{item.get('width', '')} X {item.get('length', '')}"
                 if item.get('mm_stack'):
-                    description += f" X {item.get('mm_stack', '')}"
+                    description += f" X {float(item.get('mm_stack')):.2f}"
                 
                 # Use multi_cell for description but manage positioning manually
                 pdf.multi_cell(desc_w, row_height, description, border=1, align='C', ln=1)
@@ -804,7 +804,7 @@ class PDFService:
                 desc_x = pdf.get_x()
                 description = f"{item.get('width', '')} X {item.get('length', '')}"
                 if item.get('mm_stack'):
-                    description += f" X {item.get('mm_stack', '')}"
+                    description += f" X {float(item.get('mm_stack')):.2f}"
                 
                 # Show sets if present (Itemized Mode); suppress for RN- (E&I) job cards.
                 if item.get('sets') and not is_rn_series:


### PR DESCRIPTION
- Round mm_stack calculation in sales_order.py when deriving from weight
- Format mm_stack with :.2f in pdf_service.py (job card table + weight receipt descriptions)
- Format mm_stack with :.2f in pdf_generator.py (invoice descriptions)